### PR TITLE
feature(model): switch to ViT-L/14@336px

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-clip = {git = "https://github.com/openai/CLIP.git"}
+clip = {git = "https://github.com/openai/CLIP.git", ref = "b4ae44927b78d0093b556e3ce43cbdcff422017a"}
 torch = {version = "==1.9.0", sys_platform = "!= 'linux'"}
 torchvision = {version = "==0.10.0", sys_platform = "!= 'linux'"}
 torch_linux = {file = "https://download.pytorch.org/whl/cpu/torch-1.9.0%2Bcpu-cp38-cp38-linux_x86_64.whl", version = "==1.9.0+cpu", sys_platform = "== 'linux'"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "26c4a41879d00fd14748d515e8e9aa22f38ebd9eb73ba250c07e69318eac1759"
+            "sha256": "588f19b44c5ba0a9723cbc83c7ae792411629d8cb6871298248cc6aafe20a73f"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -10,9 +10,9 @@ import torch.nn
 
 
 class Model:
-  VECTOR_SIZE = 512
+  VECTOR_SIZE = 768
   _device = 'cpu'
-  _model_name = 'ViT-B/32'
+  _model_name = 'ViT-L/14@336px'
 
   def __init__(self):
     model, preprocess = cast(


### PR DESCRIPTION
Switch to the largest OpenAI's CLIP model. This change brings quality improvements for a price of a huge performance penalty. The difference on my small test set is 16.34s vs 192.72s (+1079%) on image ingestion and 4.49s vs 7.41s (+65%) on image search.

The quality benefits are to be evaluated before merging this change.