### PR TITLE
fix: exclude query images from results

### DIFF
--- a/rclip/main.py
+++ b/rclip/main.py
@@ -129,8 +129,16 @@ class RClip:
     positive_queries = [query] + positive_queries
     sorted_similarities = self._model.compute_similarities_to_text(features, positive_queries, negative_queries)
 
+    # exclude images that were part of the query from the results
+    exclude_files = [
+      os.path.abspath(query) for query in positive_queries + negative_queries if utils.is_file_path(query)
+    ]
+
     filtered_similarities = filter(
-      lambda similarity: not self._exclude_dir_regex.match(filepaths[similarity[1]]),
+      lambda similarity: (
+        not self._exclude_dir_regex.match(filepaths[similarity[1]]) and
+        not filepaths[similarity[1]] in exclude_files
+      ),
       sorted_similarities
     )
     top_k_similarities = itertools.islice(filtered_similarities, top_k)

--- a/tests/e2e/output_snapshots/test_combine_text_query_with_image_query.txt
+++ b/tests/e2e/output_snapshots/test_combine_text_query_with_image_query.txt
@@ -1,6 +1,5 @@
 score	filepath
 0.652	"<test_images_dir>/bee.jpg"
-0.626	"<test_images_dir>/cat.jpg"
 0.482	"<test_images_dir>/cake.jpg"
 0.471	"<test_images_dir>/chessboard with rocks.JPG"
 0.449	"<test_images_dir>/black kitty.jpg"
@@ -9,3 +8,4 @@ score	filepath
 0.386	"<test_images_dir>/books.jpg"
 0.379	"<test_images_dir>/boats on a lake.jpg"
 0.367	"<test_images_dir>/black cat at night.jpg"
+0.361	"<test_images_dir>/camera lens.jpg"

--- a/tests/e2e/output_snapshots/test_search_by_image.txt
+++ b/tests/e2e/output_snapshots/test_search_by_image.txt
@@ -1,5 +1,4 @@
 score	filepath
-1.000	"<test_images_dir>/cat.jpg"
 0.787	"<test_images_dir>/black kitty.jpg"
 0.780	"<test_images_dir>/black cat sleeping on a chair.JPG"
 0.744	"<test_images_dir>/black cat at night.jpg"
@@ -9,3 +8,4 @@ score	filepath
 0.560	"<test_images_dir>/cake.jpg"
 0.558	"<test_images_dir>/camera.jpg"
 0.531	"<test_images_dir>/books.jpg"
+0.531	"<test_images_dir>/boats on a lake.jpg"


### PR DESCRIPTION
Exclude query images from results to make the query output more useful.

The reasoning for this is that if I am using an image as a query, I already know about it and don't have to look for it; therefore, there is no point in displaying it in the results.