### PR TITLE
feat(macOS): default to 'mps' for performance boost

### DIFF
--- a/rclip/const.py
+++ b/rclip/const.py
@@ -1,0 +1,6 @@
+import sys
+
+
+IS_MACOS = sys.platform == 'darwin'
+IS_LINUX = sys.platform.startswith('linux')
+IS_WINDOWS = sys.platform == 'win32' or sys.platform == 'cygwin'

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -165,7 +165,7 @@ def main():
   if is_snap():
     check_snap_permissions(current_directory)
 
-  model_instance = model.Model()
+  model_instance = model.Model(device=vars(args).get("device", "cpu"))
   datadir = utils.get_app_datadir()
   database = db.DB(datadir / 'db.sqlite3')
   rclip = RClip(model_instance, database, args.exclude_dir)

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -12,11 +12,11 @@ QueryWithMultiplier = Tuple[float, str]
 
 class Model:
   VECTOR_SIZE = 512
-  _device = 'cpu'
   _model_name = 'ViT-B-32'
   _checkpoint_name = 'openai'
 
-  def __init__(self):
+  def __init__(self, device: str = 'cpu'):
+    self._device = device
     self.__model = None
     self.__preprocess = None
     self.__tokenizer = None

--- a/rclip/utils.py
+++ b/rclip/utils.py
@@ -7,6 +7,8 @@ import requests
 import sys
 from importlib.metadata import version
 
+from rclip.const import IS_LINUX, IS_MACOS, IS_WINDOWS
+
 
 MAX_DOWNLOAD_SIZE_BYTES = 50_000_000
 DOWNLOAD_TIMEOUT_SECONDS = 60
@@ -25,11 +27,11 @@ def __get_system_datadir() -> pathlib.Path:
 
   home = pathlib.Path.home()
 
-  if sys.platform == 'win32':
+  if IS_WINDOWS:
     return home / 'AppData/Roaming'
-  elif sys.platform.startswith('linux'):
+  elif IS_LINUX:
     return home / '.local/share'
-  elif sys.platform == 'darwin':
+  elif IS_MACOS:
     return home / 'Library/Application Support'
 
   raise NotImplementedError(f'"{sys.platform}" is not supported')
@@ -73,7 +75,8 @@ def init_arg_parser() -> argparse.ArgumentParser:
   parser.add_argument('--subtract', '--sub', '-s', '-', metavar='QUERY', action='append', default=[],
                       help='a text query or a path/URL to an image file to add to the "original" query,'
                       ' can be used multiple times')
-  parser.add_argument('--top', '-t', type=top_arg_type, default=10, help='number of top results to display')
+  parser.add_argument('--top', '-t', type=top_arg_type, default=10,
+                      help='number of top results to display, default: 10')
   parser.add_argument('--filepath-only', '-f', action='store_true', default=False, help='outputs only filepaths')
   parser.add_argument(
     '--no-indexing', '--skip-index', '-n',
@@ -88,6 +91,11 @@ def init_arg_parser() -> argparse.ArgumentParser:
     ' adding this argument overrides the default of ("@eaDir", "node_modules", ".git");'
     ' WARNING: the default will be removed in v2'
   )
+  if IS_MACOS:
+    import torch.backends.mps
+    if torch.backends.mps.is_available():
+      parser.add_argument('--device', '-d', default='mps', choices=['cpu', 'mps'],
+                          help='device to run on, default: mps')
   return parser
 
 


### PR DESCRIPTION
This PR makes `rclip` use `mps` on macOS if it's available. It also adds the `--device cpu` support to allow manually switch back to using CPU on macOS.

Impact, measured on M1 Max, indexing 1.28 million ImageNet-1k dataset:
- CPU: 8 hours 31 minutes 26.68 seconds
- MPS: 3 hours 8 minutes 50.21 seconds

Indexing imagenet on mps took 37% of time it used to take to index it on CPU.