### PR TITLE
feat(ux): unify indexing progressbars to provide better insight into the total indexing time + speed it up a bit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rclip"
-version = "1.7.0a2"
+version = "1.7.0a3"
 description = "AI-Powered Command-Line Photo Search Tool"
 authors = ["Yurij Mikhalevich <yurij@mikhalevi.ch>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rclip"
-version = "1.7.0a1"
+version = "1.7.0a2"
 description = "AI-Powered Command-Line Photo Search Tool"
 authors = ["Yurij Mikhalevich <yurij@mikhalevi.ch>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rclip"
-version = "1.7.0a0"
+version = "1.7.0a1"
 description = "AI-Powered Command-Line Photo Search Tool"
 authors = ["Yurij Mikhalevich <yurij@mikhalevi.ch>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rclip"
-version = "1.6.1"
+version = "1.7.0a0"
 description = "AI-Powered Command-Line Photo Search Tool"
 authors = ["Yurij Mikhalevich <yurij@mikhalevi.ch>"]
 license = "MIT"

--- a/rclip/fs.py
+++ b/rclip/fs.py
@@ -1,0 +1,23 @@
+import os
+import re
+from typing import Callable
+
+COUNT_FILES_UPDATE_EVERY = 1000
+
+
+def count_files(
+  directory: str,
+  exclude_dir_re: re.Pattern[str],
+  file_re: re.Pattern[str],
+  on_change: Callable[[int], None]
+) -> None:
+  prev_update_count = 0
+  count = 0
+  for root, _, files in os.walk(directory):
+    if exclude_dir_re.match(root):
+      continue
+    count += len(list(f for f in files if file_re.match(f)))
+    if count - prev_update_count >= COUNT_FILES_UPDATE_EVERY:
+      on_change(count)
+      prev_update_count = count
+  on_change(count)

--- a/rclip/fs.py
+++ b/rclip/fs.py
@@ -12,7 +12,7 @@ def count_files(
 ) -> None:
   prev_update_count = 0
   count = 0
-  for _ in recursive_walk(directory, exclude_dir_re, file_re):
+  for _ in walk(directory, exclude_dir_re, file_re):
     count += 1
     if count - prev_update_count >= COUNT_FILES_UPDATE_EVERY:
       on_change(count)
@@ -20,11 +20,12 @@ def count_files(
   on_change(count)
 
 
-def recursive_walk(
+def walk(
   directory: str,
   exclude_dir_re: Pattern[str],
   file_re: Pattern[str],
 ):
+  '''Walks through a directory recursively and yields files that match the given regex'''
   dirs_to_process = [directory]
   while dirs_to_process:
     dir = dirs_to_process.pop()

--- a/rclip/fs.py
+++ b/rclip/fs.py
@@ -34,4 +34,4 @@ def recursive_walk(
           if not exclude_dir_re.match(entry.path):
             dirs_to_process.append(entry.path)
         elif entry.is_file() and file_re.match(entry.name):
-          yield entry.path
+          yield entry

--- a/rclip/fs.py
+++ b/rclip/fs.py
@@ -1,14 +1,13 @@
 import os
-import re
-from typing import Callable
+from typing import Callable, Pattern
 
 COUNT_FILES_UPDATE_EVERY = 1000
 
 
 def count_files(
   directory: str,
-  exclude_dir_re: re.Pattern[str],
-  file_re: re.Pattern[str],
+  exclude_dir_re: Pattern[str],
+  file_re: Pattern[str],
   on_change: Callable[[int], None]
 ) -> None:
   prev_update_count = 0

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 import threading
-from typing import AnyStr, Iterable, List, NamedTuple, Optional, Tuple, TypedDict, cast
+from typing import Iterable, List, NamedTuple, Optional, Tuple, TypedDict, cast
 
 import numpy as np
 from tqdm import tqdm
@@ -27,7 +27,7 @@ class ImageMeta(TypedDict):
 PathMetaVector = Tuple[str, ImageMeta, model.FeatureVector]
 
 
-def get_image_meta(entry: os.DirEntry[AnyStr]) -> ImageMeta:
+def get_image_meta(entry: os.DirEntry) -> ImageMeta:
   stat = entry.stat()
   return ImageMeta(modified_at=stat.st_mtime, size=stat.st_size)
 

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -123,10 +123,10 @@ def init_arg_parser() -> argparse.ArgumentParser:
     help='preview height in pixels, default: 400',
   )
   parser.add_argument(
-    '--no-indexing', '--skip-index', '-n',
+    '--no-indexing', '--skip-index', '--skip-indexing', '-n',
     action='store_true',
     default=False,
-    help='allows to skip re-indexing entirely on repeated runs if you know no new images were added'
+    help='allows to skip updating the index if no images were added, changed, or removed'
   )
   parser.add_argument(
     '--exclude-dir',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   For a detailed demonstration, watch the video: https://www.youtube.com/watch?v=tAJHXOkHidw.
 
   You can use another image as a query by passing a file path or even an URL to the image file to **rclip** and combine multiple queries. Check out the project's README on GitHub for more usage examples: https://github.com/yurijmikhalevich/rclip#readme.
-version: 1.7.0a1
+version: 1.7.0a2
 website: https://github.com/yurijmikhalevich/rclip
 contact: yurij@mikhalevi.ch
 passthrough:
@@ -33,7 +33,7 @@ apps:
 parts:
   rclip:
     plugin: python
-    source: ./snap/local/rclip-1.7.0a1.tar.gz
+    source: ./snap/local/rclip-1.7.0a2.tar.gz
     build-packages:
       - python3-pip
     build-environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   For a detailed demonstration, watch the video: https://www.youtube.com/watch?v=tAJHXOkHidw.
 
   You can use another image as a query by passing a file path or even an URL to the image file to **rclip** and combine multiple queries. Check out the project's README on GitHub for more usage examples: https://github.com/yurijmikhalevich/rclip#readme.
-version: 1.6.1
+version: 1.7.0a0
 website: https://github.com/yurijmikhalevich/rclip
 contact: yurij@mikhalevi.ch
 passthrough:
@@ -33,7 +33,7 @@ apps:
 parts:
   rclip:
     plugin: python
-    source: ./snap/local/rclip-1.6.1.tar.gz
+    source: ./snap/local/rclip-1.7.0a0.tar.gz
     build-packages:
       - python3-pip
     build-environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   For a detailed demonstration, watch the video: https://www.youtube.com/watch?v=tAJHXOkHidw.
 
   You can use another image as a query by passing a file path or even an URL to the image file to **rclip** and combine multiple queries. Check out the project's README on GitHub for more usage examples: https://github.com/yurijmikhalevich/rclip#readme.
-version: 1.7.0a2
+version: 1.7.0a3
 website: https://github.com/yurijmikhalevich/rclip
 contact: yurij@mikhalevi.ch
 passthrough:
@@ -33,7 +33,7 @@ apps:
 parts:
   rclip:
     plugin: python
-    source: ./snap/local/rclip-1.7.0a2.tar.gz
+    source: ./snap/local/rclip-1.7.0a3.tar.gz
     build-packages:
       - python3-pip
     build-environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   For a detailed demonstration, watch the video: https://www.youtube.com/watch?v=tAJHXOkHidw.
 
   You can use another image as a query by passing a file path or even an URL to the image file to **rclip** and combine multiple queries. Check out the project's README on GitHub for more usage examples: https://github.com/yurijmikhalevich/rclip#readme.
-version: 1.7.0a0
+version: 1.7.0a1
 website: https://github.com/yurijmikhalevich/rclip
 contact: yurij@mikhalevi.ch
 passthrough:
@@ -33,7 +33,7 @@ apps:
 parts:
   rclip:
     plugin: python
-    source: ./snap/local/rclip-1.7.0a0.tar.gz
+    source: ./snap/local/rclip-1.7.0a1.tar.gz
     build-packages:
       - python3-pip
     build-environment:


### PR DESCRIPTION
Closes #75 

The speed-up is especially noticeable on repeated runs because walking over the directories now uses a more effective custom implementation using `os.scandir` instead of `os.walk`.

The speedup is achieved by:
- truly skipping excluded directories
- at least halving the number of `os.stat` requests
- avoiding storing more than batch size file paths in memory at once (`os.walk` stores all files from the current subdir in memory)