### PR TITLE
ci: fix snap build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
   pypi:
     needs: validate
     runs-on: ubuntu-22.04
+    if: false
     permissions:
       id-token: write
     steps:
@@ -93,7 +94,9 @@ jobs:
           mkdir snap/local
           cp -v dist/rclip-*.tar.gz snap/local
       - run: sudo snap install snapcraft --classic
-      - run: snapcraft remote-build --launchpad-accept-public-upload
+      - run: |
+        export SNAPCRAFT_REMOTE_BUILD_STRATEGY="force-fallback"
+        snapcraft remote-build --launchpad-accept-public-upload
       - name: Validate built snap
         run: |
           sudo snap install rclip_*_amd64.snap --dangerous
@@ -124,6 +127,7 @@ jobs:
   appimage:
     needs: [parse_tag, validate]
     runs-on: ubuntu-20.04
+    if: false
     steps:
       - uses: actions/checkout@v3
       - name: Set up APPDIR for after_bundle
@@ -183,7 +187,8 @@ jobs:
   create_release:
     needs: [parse_tag, pypi, snap, appimage, windows]
     # the windows job doesn't run for pre-releases, but we need to create a release for pre-releases too
-    if: ${{ !cancelled() }}
+    # if: ${{ !cancelled() }}
+    if: false
     runs-on: ubuntu-22.04
     steps:
       # if any of the needs jobs fail, we don't want to create a release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,6 @@ jobs:
   pypi:
     needs: validate
     runs-on: ubuntu-22.04
-    if: false
     permissions:
       id-token: write
     steps:
@@ -95,6 +94,7 @@ jobs:
           cp -v dist/rclip-*.tar.gz snap/local
       - run: sudo snap install snapcraft --classic
       - run: |
+          export SNAPCRAFT_REMOTE_BUILD_STRATEGY="force-fallback"
           snapcraft remote-build --launchpad-accept-public-upload
       - name: Validate built snap
         run: |
@@ -126,7 +126,6 @@ jobs:
   appimage:
     needs: [parse_tag, validate]
     runs-on: ubuntu-20.04
-    if: false
     steps:
       - uses: actions/checkout@v3
       - name: Set up APPDIR for after_bundle
@@ -186,8 +185,7 @@ jobs:
   create_release:
     needs: [parse_tag, pypi, snap, appimage, windows]
     # the windows job doesn't run for pre-releases, but we need to create a release for pre-releases too
-    # if: ${{ !cancelled() }}
-    if: false
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-22.04
     steps:
       # if any of the needs jobs fail, we don't want to create a release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,6 @@ jobs:
           cp -v dist/rclip-*.tar.gz snap/local
       - run: sudo snap install snapcraft --classic
       - run: |
-          export SNAPCRAFT_REMOTE_BUILD_STRATEGY="force-fallback"
           snapcraft remote-build --launchpad-accept-public-upload
       - name: Validate built snap
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,8 +95,8 @@ jobs:
           cp -v dist/rclip-*.tar.gz snap/local
       - run: sudo snap install snapcraft --classic
       - run: |
-        export SNAPCRAFT_REMOTE_BUILD_STRATEGY="force-fallback"
-        snapcraft remote-build --launchpad-accept-public-upload
+          export SNAPCRAFT_REMOTE_BUILD_STRATEGY="force-fallback"
+          snapcraft remote-build --launchpad-accept-public-upload
       - name: Validate built snap
         run: |
           sudo snap install rclip_*_amd64.snap --dangerous

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rclip"
-version = "1.8.10a1"
+version = "1.8.10a2"
 description = "AI-Powered Command-Line Photo Search Tool"
 authors = ["Yurij Mikhalevich <yurij@mikhalevi.ch>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rclip"
-version = "1.8.9"
+version = "1.8.10a0"
 description = "AI-Powered Command-Line Photo Search Tool"
 authors = ["Yurij Mikhalevich <yurij@mikhalevi.ch>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rclip"
-version = "1.8.10a0"
+version = "1.8.10a1"
 description = "AI-Powered Command-Line Photo Search Tool"
 authors = ["Yurij Mikhalevich <yurij@mikhalevi.ch>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rclip"
-version = "1.8.10a2"
+version = "1.8.10a3"
 description = "AI-Powered Command-Line Photo Search Tool"
 authors = ["Yurij Mikhalevich <yurij@mikhalevi.ch>"]
 license = "MIT"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   For a detailed demonstration, watch the video: https://www.youtube.com/watch?v=tAJHXOkHidw.
 
   You can use another image as a query by passing a file path or even an URL to the image file to **rclip** and combine multiple queries. Check out the project's README on GitHub for more usage examples: https://github.com/yurijmikhalevich/rclip#readme.
-version: 1.8.10a2
+version: 1.8.10a3
 website: https://github.com/yurijmikhalevich/rclip
 contact: yurij@mikhalevi.ch
 passthrough:
@@ -31,7 +31,7 @@ apps:
 parts:
   rclip:
     plugin: python
-    source: ./snap/local/rclip-1.8.10a2.tar.gz
+    source: ./snap/local/rclip-1.8.10a3.tar.gz
     build-packages:
       - python3-pip
     build-environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   For a detailed demonstration, watch the video: https://www.youtube.com/watch?v=tAJHXOkHidw.
 
   You can use another image as a query by passing a file path or even an URL to the image file to **rclip** and combine multiple queries. Check out the project's README on GitHub for more usage examples: https://github.com/yurijmikhalevich/rclip#readme.
-version: 1.8.9
+version: 1.8.10a0
 website: https://github.com/yurijmikhalevich/rclip
 contact: yurij@mikhalevi.ch
 passthrough:
@@ -31,7 +31,7 @@ apps:
 parts:
   rclip:
     plugin: python
-    source: ./snap/local/rclip-1.8.9.tar.gz
+    source: ./snap/local/rclip-1.8.10a0.tar.gz
     build-packages:
       - python3-pip
     build-environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   For a detailed demonstration, watch the video: https://www.youtube.com/watch?v=tAJHXOkHidw.
 
   You can use another image as a query by passing a file path or even an URL to the image file to **rclip** and combine multiple queries. Check out the project's README on GitHub for more usage examples: https://github.com/yurijmikhalevich/rclip#readme.
-version: 1.8.10a1
+version: 1.8.10a2
 website: https://github.com/yurijmikhalevich/rclip
 contact: yurij@mikhalevi.ch
 passthrough:
@@ -31,7 +31,7 @@ apps:
 parts:
   rclip:
     plugin: python
-    source: ./snap/local/rclip-1.8.10a1.tar.gz
+    source: ./snap/local/rclip-1.8.10a2.tar.gz
     build-packages:
       - python3-pip
     build-environment:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   For a detailed demonstration, watch the video: https://www.youtube.com/watch?v=tAJHXOkHidw.
 
   You can use another image as a query by passing a file path or even an URL to the image file to **rclip** and combine multiple queries. Check out the project's README on GitHub for more usage examples: https://github.com/yurijmikhalevich/rclip#readme.
-version: 1.8.10a0
+version: 1.8.10a1
 website: https://github.com/yurijmikhalevich/rclip
 contact: yurij@mikhalevi.ch
 passthrough:
@@ -31,7 +31,7 @@ apps:
 parts:
   rclip:
     plugin: python
-    source: ./snap/local/rclip-1.8.10a0.tar.gz
+    source: ./snap/local/rclip-1.8.10a1.tar.gz
     build-packages:
       - python3-pip
     build-environment:


### PR DESCRIPTION
Adding this before buildings snap packages to fix snapcraft remote auth. Using the new strategy breaks the auth for some reason and forces us to reauth in CI.

```sh
export SNAPCRAFT_REMOTE_BUILD_STRATEGY="force-fallback"
```