### PR TITLE
feat: speedup text-only search by up to 50% (3.8s → 1.9s) and reduce text-only search RAM consumption by up to 3.8 times (1.7Gb → 0.45Gb)

### DIFF
--- a/rclip/model.py
+++ b/rclip/model.py
@@ -37,14 +37,16 @@ class Model:
     self._tokenizer_var = None
 
     self._text_model_path = helpers.get_app_datadir() / f'{self._model_name}_{self._checkpoint_name}_text.pth'
-    self._text_model_version_path = helpers.get_app_datadir() / f'{self._model_name}_{self._checkpoint_name}_text.version'
+    self._text_model_version_path = (
+      helpers.get_app_datadir() / f'{self._model_name}_{self._checkpoint_name}_text.version'
+    )
 
   @property
   def _tokenizer(self):
     if not self._tokenizer_var:
       self._tokenizer_var = open_clip.get_tokenizer(self._model_name)
     return self._tokenizer_var
-  
+
   def _load_model(self):
     self._model_var, _, self._preprocess_var = open_clip.create_model_and_transforms(
       self._model_name,
@@ -74,10 +76,10 @@ class Model:
   def _should_update_text_model(self):
     if not self._text_model_path.exists():
       return True
-    
+
     if not self._text_model_version_path.exists():
       return True
-    
+
     with self._text_model_version_path.open('r') as f:
       text_model_version = f.read().strip()
 
@@ -88,8 +90,8 @@ class Model:
   def _model(self):
     if not self._model_var:
       self._load_model()
-    return self._model_var
-  
+    return cast(open_clip.CLIP, self._model_var)
+
   @property
   def _model_text(self):
     if self._model_var:
@@ -106,13 +108,14 @@ class Model:
     if not self._model_var:
       self._load_model()
 
-    return self._model_var
+    return cast(open_clip.CLIP, self._model_var)
 
   @property
   def _preprocess(self):
+    from torchvision.transforms import Compose
     if not self._preprocess_var:
       self._load_model()
-    return self._preprocess_var
+    return cast(Compose, self._preprocess_var)
 
   def compute_image_features(self, images: List[Image.Image]) -> np.ndarray:
     import torch

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -66,10 +66,6 @@ def get_terminal_text_width() -> int:
     return DEFAULT_TERMINAL_TEXT_WIDTH
 
 
-def get_rclip_version() -> str:
-  return version("rclip")
-
-
 class HelpFormatter(argparse.RawDescriptionHelpFormatter):
   def __init__(self, prog: str, indent_increment: int = 2, max_help_position: int = 24) -> None:
     text_width = get_terminal_text_width()
@@ -102,7 +98,7 @@ def init_arg_parser() -> argparse.ArgumentParser:
     'get help:\n'
     '  https://github.com/yurijmikhalevich/rclip/discussions/new/choose\n\n',
   )
-  version_str = f'rclip {get_rclip_version()}'
+  version_str = f'rclip {version("rclip")}'
   parser.add_argument('--version', '-v', action='version', version=version_str, help=f'prints "{version_str}"')
   parser.add_argument('query', help='a text query or a path/URL to an image file')
   parser.add_argument('--add', '-a', '+', metavar='QUERY', action='append', default=[],

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -66,6 +66,10 @@ def get_terminal_text_width() -> int:
     return DEFAULT_TERMINAL_TEXT_WIDTH
 
 
+def get_rclip_version() -> str:
+  return version("rclip")
+
+
 class HelpFormatter(argparse.RawDescriptionHelpFormatter):
   def __init__(self, prog: str, indent_increment: int = 2, max_help_position: int = 24) -> None:
     text_width = get_terminal_text_width()
@@ -98,7 +102,7 @@ def init_arg_parser() -> argparse.ArgumentParser:
     'get help:\n'
     '  https://github.com/yurijmikhalevich/rclip/discussions/new/choose\n\n',
   )
-  version_str = f'rclip {version("rclip")}'
+  version_str = f'rclip {get_rclip_version()}'
   parser.add_argument('--version', '-v', action='version', version=version_str, help=f'prints "{version_str}"')
   parser.add_argument('query', help='a text query or a path/URL to an image file')
   parser.add_argument('--add', '-a', '+', metavar='QUERY', action='append', default=[],

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -25,21 +25,21 @@ def test_text_model_produces_the_same_vector_as_the_main_model(monkeypatch: pyte
   with tempfile.TemporaryDirectory() as tmpdirname:
     monkeypatch.setenv('RCLIP_DATADIR', tmpdirname)
     model = Model()
-    assert model._model_var == None  # type: ignore
-    assert model._model_text_var == None  # type: ignore
+    assert model._model_var is None  # type: ignore
+    assert model._model_text_var is None  # type: ignore
 
     model._load_model()  # type: ignore
-    assert model._model_var != None  # type: ignore
-    assert model._model_var.transformer != None  # type: ignore
-    assert model._model_var.visual != None  # type: ignore
+    assert model._model_var is not None  # type: ignore
+    assert model._model_var.transformer is not None  # type: ignore
+    assert model._model_var.visual is not None  # type: ignore
 
-    assert model._model_text_var == None  # type: ignore
+    assert model._model_text_var is None  # type: ignore
     text_model = model._get_text_model(model._model_var)  # type: ignore
-    assert text_model.transformer != None  # type: ignore
-    assert text_model.visual == None  # type: ignore
+    assert text_model.transformer is not None  # type: ignore
+    assert text_model.visual is None  # type: ignore
 
     full_model = model._model_var  # type: ignore
-    assert full_model.visual != None  # type: ignore
+    assert full_model.visual is not None  # type: ignore
 
     def encode_text(clip_model: open_clip.CLIP, text: List[str]):
       return clip_model.encode_text(model._tokenizer(text).to(model._device))  # type: ignore
@@ -53,24 +53,24 @@ def test_loads_text_model_when_text_processing_only_requested_and_checkpoint_exi
   with tempfile.TemporaryDirectory() as tmpdirname:
     monkeypatch.setenv('RCLIP_DATADIR', tmpdirname)
     model1 = Model()
-    assert model1._model_var == None  # type: ignore
-    assert model1._model_text_var == None  # type: ignore
+    assert model1._model_var is None  # type: ignore
+    assert model1._model_text_var is None  # type: ignore
 
     full_model = cast(open_clip.CLIP, model1._model)  # type: ignore
-    assert model1._model_var != None  # type: ignore
-    assert model1._model_var.transformer != None  # type: ignore
-    assert model1._model_var.visual != None  # type: ignore
-    assert model1._model_text_var == None  # type: ignore
+    assert model1._model_var is not None  # type: ignore
+    assert model1._model_var.transformer is not None  # type: ignore
+    assert model1._model_var.visual is not None  # type: ignore
+    assert model1._model_text_var is None  # type: ignore
 
     model2 = Model()
-    assert model2._model_var == None  # type: ignore
-    assert model2._model_text_var == None  # type: ignore
+    assert model2._model_var is None  # type: ignore
+    assert model2._model_text_var is None  # type: ignore
 
     text_model = cast(open_clip.CLIP, model2._model_text)  # type: ignore
-    assert model2._model_var == None  # type: ignore
-    assert model2._model_text_var != None  # type: ignore
-    assert model2._model_text_var.transformer != None  # type: ignore
-    assert model2._model_text_var.visual == None  # type: ignore
+    assert model2._model_var is None  # type: ignore
+    assert model2._model_text_var is not None  # type: ignore
+    assert model2._model_text_var.transformer is not None  # type: ignore
+    assert model2._model_text_var.visual is None  # type: ignore
     assert model2._model_text_var == text_model  # type: ignore
 
     def encode_text(clip_model: open_clip.CLIP, text: List[str]):
@@ -81,15 +81,17 @@ def test_loads_text_model_when_text_processing_only_requested_and_checkpoint_exi
     assert torch.equal(encode_text(full_model, ['cat', 'dog', 'bird']), encode_text(text_model, ['cat', 'dog', 'bird']))
 
 
-def test_loads_full_model_when_text_processing_only_requested_and_checkpoint_doesnt_exist(monkeypatch: pytest.MonkeyPatch):
+def test_loads_full_model_when_text_processing_only_requested_and_checkpoint_doesnt_exist(
+  monkeypatch: pytest.MonkeyPatch
+):
   with tempfile.TemporaryDirectory() as tmpdirname:
     monkeypatch.setenv('RCLIP_DATADIR', tmpdirname)
     model = Model()
-    assert model._model_var == None  # type: ignore
-    assert model._model_text_var == None  # type: ignore
+    assert model._model_var is None  # type: ignore
+    assert model._model_text_var is None  # type: ignore
 
     _ = model._model_text  # type: ignore
-    assert model._model_var != None  # type: ignore
-    assert model._model_var.transformer != None  # type: ignore
-    assert model._model_var.visual != None  # type: ignore
-    assert model._model_text_var == None  # type: ignore
+    assert model._model_var is not None  # type: ignore
+    assert model._model_var.transformer is not None  # type: ignore
+    assert model._model_var.visual is not None  # type: ignore
+    assert model._model_text_var is None  # type: ignore

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,3 +1,9 @@
+import tempfile
+from typing import List, cast
+
+import open_clip
+import pytest
+import torch
 from rclip.model import Model
 
 
@@ -13,3 +19,77 @@ def test_extract_query_multiplier():
   assert Model._extract_query_multiplier('whatever:cat') == (1., 'whatever:cat')  # type: ignore
   assert (Model._extract_query_multiplier('1.5:complex and long query') ==  # type: ignore
           (1.5, 'complex and long query'))
+
+
+def test_text_model_produces_the_same_vector_as_the_main_model(monkeypatch: pytest.MonkeyPatch):
+  with tempfile.TemporaryDirectory() as tmpdirname:
+    monkeypatch.setenv('RCLIP_DATADIR', tmpdirname)
+    model = Model()
+    assert model._model_var == None  # type: ignore
+    assert model._model_text_var == None  # type: ignore
+
+    model._load_model()  # type: ignore
+    assert model._model_var != None  # type: ignore
+    assert model._model_var.transformer != None  # type: ignore
+    assert model._model_var.visual != None  # type: ignore
+
+    assert model._model_text_var == None  # type: ignore
+    text_model = model._get_text_model(model._model_var)  # type: ignore
+    assert text_model.transformer != None  # type: ignore
+    assert text_model.visual == None  # type: ignore
+
+    full_model = model._model_var  # type: ignore
+    assert full_model.visual != None  # type: ignore
+
+    def encode_text(clip_model: open_clip.CLIP, text: List[str]):
+      return clip_model.encode_text(model._tokenizer(text).to(model._device))  # type: ignore
+
+    assert torch.equal(encode_text(full_model, ['cat']), encode_text(text_model, ['cat']))
+    assert torch.equal(encode_text(full_model, ['cat', 'dog']), encode_text(text_model, ['cat', 'dog']))
+    assert torch.equal(encode_text(full_model, ['cat', 'dog', 'bird']), encode_text(text_model, ['cat', 'dog', 'bird']))
+
+
+def test_loads_text_model_when_text_processing_only_requested_and_checkpoint_exists(monkeypatch: pytest.MonkeyPatch):
+  with tempfile.TemporaryDirectory() as tmpdirname:
+    monkeypatch.setenv('RCLIP_DATADIR', tmpdirname)
+    model1 = Model()
+    assert model1._model_var == None  # type: ignore
+    assert model1._model_text_var == None  # type: ignore
+
+    full_model = cast(open_clip.CLIP, model1._model)  # type: ignore
+    assert model1._model_var != None  # type: ignore
+    assert model1._model_var.transformer != None  # type: ignore
+    assert model1._model_var.visual != None  # type: ignore
+    assert model1._model_text_var == None  # type: ignore
+
+    model2 = Model()
+    assert model2._model_var == None  # type: ignore
+    assert model2._model_text_var == None  # type: ignore
+
+    text_model = cast(open_clip.CLIP, model2._model_text)  # type: ignore
+    assert model2._model_var == None  # type: ignore
+    assert model2._model_text_var != None  # type: ignore
+    assert model2._model_text_var.transformer != None  # type: ignore
+    assert model2._model_text_var.visual == None  # type: ignore
+    assert model2._model_text_var == text_model  # type: ignore
+
+    def encode_text(clip_model: open_clip.CLIP, text: List[str]):
+      return clip_model.encode_text(model1._tokenizer(text).to(model1._device))  # type: ignore
+
+    assert torch.equal(encode_text(full_model, ['cat']), encode_text(text_model, ['cat']))
+    assert torch.equal(encode_text(full_model, ['cat', 'dog']), encode_text(text_model, ['cat', 'dog']))
+    assert torch.equal(encode_text(full_model, ['cat', 'dog', 'bird']), encode_text(text_model, ['cat', 'dog', 'bird']))
+
+
+def test_loads_full_model_when_text_processing_only_requested_and_checkpoint_doesnt_exist(monkeypatch: pytest.MonkeyPatch):
+  with tempfile.TemporaryDirectory() as tmpdirname:
+    monkeypatch.setenv('RCLIP_DATADIR', tmpdirname)
+    model = Model()
+    assert model._model_var == None  # type: ignore
+    assert model._model_text_var == None  # type: ignore
+
+    _ = model._model_text  # type: ignore
+    assert model._model_var != None  # type: ignore
+    assert model._model_var.transformer != None  # type: ignore
+    assert model._model_var.visual != None  # type: ignore
+    assert model._model_text_var == None  # type: ignore


### PR DESCRIPTION
Related to #7.

This PR reduces the text-only search time and RAM consumption by loading only the text transformer unless the user wants to use an image as the search query.

### Now

<img width="689" alt="image" src="https://github.com/yurijmikhalevich/rclip/assets/4187729/961bd504-fdd5-438d-8a7f-8c184bce0c62">

### Before

<img width="702" alt="image" src="https://github.com/yurijmikhalevich/rclip/assets/4187729/f935146a-cc9c-4de7-ab24-28cc81fac397">
