### PR TITLE
feat: arguments for loading custom model and checkpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "main"
-    ]
-}

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -206,12 +206,14 @@ class RClip:
       filepaths.append(image["filepath"])
       features.append(np.frombuffer(image["vector"], np.float32))
     if not filepaths:
-      return [], np.ndarray(shape=(0, model.Model.VECTOR_SIZE))
+      return [], np.ndarray(shape=(0, self._model.get_vector_size()))
     return filepaths, np.stack(features)
 
 
 def init_rclip(
   working_directory: str,
+  model_name: str,
+  checkpoint_name: str,
   indexing_batch_size: int,
   device: str = "cpu",
   exclude_dir: Optional[List[str]] = None,
@@ -222,7 +224,7 @@ def init_rclip(
   db_path = datadir / "db.sqlite3"
 
   database = db.DB(db_path)
-  model_instance = model.Model(device=device or "cpu")
+  model_instance = model.Model(device=device or "cpu", model_name=model_name, checkpoint_name=checkpoint_name)
   rclip = RClip(
     model_instance=model_instance,
     database=database,
@@ -247,6 +249,8 @@ def main():
 
   rclip, _, db = init_rclip(
     current_directory,
+    args.model_name,
+    args.checkpoint_name,
     args.indexing_batch_size,
     vars(args).get("device", "cpu"),
     args.exclude_dir,

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -245,7 +245,8 @@ def main():
 
   if args.list_pretrained:
       from open_clip import list_pretrained
-      print(list_pretrained())
+      print(list_pretrained(as_str=True))
+      sys.exit(0)
 
   current_directory = os.getcwd()
   if is_snap():

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -249,8 +249,8 @@ def main():
 
   rclip, _, db = init_rclip(
     current_directory,
-    args.model_name,
-    args.checkpoint_name,
+    args.model_checkpoint.split(",")[0],
+    args.model_checkpoint.split(",")[1],
     args.indexing_batch_size,
     vars(args).get("device", "cpu"),
     args.exclude_dir,

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -249,8 +249,8 @@ def main():
 
   rclip, _, db = init_rclip(
     current_directory,
-    args.model_checkpoint.split(",")[0],
-    args.model_checkpoint.split(",")[1],
+    str(args.model_checkpoint).split(",")[0],
+    str(args.model_checkpoint).split(",")[1],
     args.indexing_batch_size,
     vars(args).get("device", "cpu"),
     args.exclude_dir,

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -243,6 +243,10 @@ def main():
   arg_parser = helpers.init_arg_parser()
   args = arg_parser.parse_args()
 
+  if args.list_pretrained:
+      from open_clip import list_pretrained
+      print(list_pretrained())
+
   current_directory = os.getcwd()
   if is_snap():
     check_snap_permissions(current_directory)

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -249,8 +249,8 @@ def main():
 
   rclip, _, db = init_rclip(
     current_directory,
-    str(args.model_checkpoint).split(",")[0],
-    str(args.model_checkpoint).split(",")[1],
+    str(args.model_checkpoint).split(":")[0],
+    str(args.model_checkpoint).split(":")[1],
     args.indexing_batch_size,
     vars(args).get("device", "cpu"),
     args.exclude_dir,

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -21,7 +21,7 @@ def get_open_clip_version():
 
 class Model:
 
-  def __init__(self, device: str = "cpu", model_name, checkpoint_name):
+  def __init__(self, device: str = "cpu", model_name: str = "", checkpoint_name: str = ""):
     self._device = device
     self._model_name = model_name
     self._checkpoint_name = checkpoint_name

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -196,7 +196,7 @@ class Model:
     elif image_features is not None:
       return image_features
     else:
-      return np.zeros(Model.VECTOR_SIZE, dtype=np.float32)
+      return np.zeros(self.get_vector_size(), dtype=np.float32)
 
   def compute_similarities_to_text(
     self, item_features: FeatureVector, positive_queries: List[str], negative_queries: List[str]

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -21,7 +21,7 @@ def get_open_clip_version():
 
 class Model:
 
-  def __init__(self, device: str = "cpu", model_name: str, checkpoint_name: str):
+  def __init__(self, device: str = "cpu", model_name, checkpoint_name):
     self._device = device
     self._model_name = model_name
     self._checkpoint_name = checkpoint_name

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -11,7 +11,6 @@ import requests
 import sys
 from importlib.metadata import version
 
-from open_clip import list_pretrained
 from rclip.const import IMAGE_RAW_EXT, IS_LINUX, IS_MACOS, IS_WINDOWS
 
 
@@ -103,9 +102,8 @@ def init_arg_parser() -> argparse.ArgumentParser:
     "  https://github.com/yurijmikhalevich/rclip/discussions/new/choose\n\n",
   )
   version_str = f"rclip {version('rclip')}"
-  pretrained_list_str = str(list_pretrained(as_str=True))
   parser.add_argument("--version", "-v", action="version", version=version_str, help=f'prints "{version_str}"')
-  parser.add_argument("--list-pretrained", "-l", action="pretrained_list", pretrained_list=pretrained_list_str, help="list pretrained OpenCLIP model checkpoints")
+  parser.add_argument("--list-pretrained", "-l", action="store_true", help="list pretrained OpenCLIP model checkpoints")
   parser.add_argument("query", help="a text query or a path/URL to an image file")
   parser.add_argument(
     "--add",

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -11,6 +11,7 @@ import requests
 import sys
 from importlib.metadata import version
 
+from open_clip import list_pretrained
 from rclip.const import IMAGE_RAW_EXT, IS_LINUX, IS_MACOS, IS_WINDOWS
 
 
@@ -102,7 +103,9 @@ def init_arg_parser() -> argparse.ArgumentParser:
     "  https://github.com/yurijmikhalevich/rclip/discussions/new/choose\n\n",
   )
   version_str = f"rclip {version('rclip')}"
+  pretrained_list_str = str(list_pretrained(as_str=True))
   parser.add_argument("--version", "-v", action="version", version=version_str, help=f'prints "{version_str}"')
+  parser.add_argument("--list-pretrained", "-l", action="pretrained_list", pretrained_list=pretrained_list_str, help="list pretrained OpenCLIP model checkpoints")
   parser.add_argument("query", help="a text query or a path/URL to an image file")
   parser.add_argument(
     "--add",
@@ -155,8 +158,8 @@ def init_arg_parser() -> argparse.ArgumentParser:
     "--model-checkpoint",
     "-M",
     type=str,
-    default="ViT-B-32-quickgelu,openai",
-    help="OpenCLIP model and checkpoint name; default: ViT-B-32-quickgelu,openai",
+    default="ViT-B-32-quickgelu:openai",
+    help="OpenCLIP model and checkpoint name; default = ViT-B-32-quickgelu:openai",
   )
   parser.add_argument(
     "--no-indexing",

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -152,18 +152,11 @@ def init_arg_parser() -> argparse.ArgumentParser:
     help="preview height in pixels; default: 400",
   )
   parser.add_argument(
-    "--model-name",
+    "--model-checkpoint",
     "-M",
     type=str,
-    default="ViT-B-32",
-    help="OpenCLIP model name",
-  )
-  parser.add_argument(
-    "--checkpoint-name",
-    "-C",
-    type=str,
-    default="datacomp_xl_s13b_b90k",
-    help="OpenCLIP checkpoint name",
+    default="ViT-B-32-quickgelu,openai",
+    help="OpenCLIP model and checkpoint name; default: ViT-B-32-quickgelu,openai",
   )
   parser.add_argument(
     "--no-indexing",

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -152,6 +152,20 @@ def init_arg_parser() -> argparse.ArgumentParser:
     help="preview height in pixels; default: 400",
   )
   parser.add_argument(
+    "--model-name",
+    "-M",
+    type=str,
+    default="ViT-B-32",
+    help="OpenCLIP model name",
+  )
+  parser.add_argument(
+    "--checkpoint-name",
+    "-C",
+    type=str,
+    default="datacomp_xl_s13b_b90k",
+    help="OpenCLIP checkpoint name",
+  )
+  parser.add_argument(
     "--no-indexing",
     "--skip-index",
     "--skip-indexing",

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -104,7 +104,7 @@ def init_arg_parser() -> argparse.ArgumentParser:
   version_str = f"rclip {version('rclip')}"
   parser.add_argument("--version", "-v", action="version", version=version_str, help=f'prints "{version_str}"')
   parser.add_argument("--list-pretrained", "-l", action="store_true", help="list pretrained OpenCLIP model checkpoints")
-  parser.add_argument("query", help="a text query or a path/URL to an image file")
+  parser.add_argument("query", nargs='?', help="a text query or a path/URL to an image file")
   parser.add_argument(
     "--add",
     "-a",


### PR DESCRIPTION
###  Here's what the PR accomplishes
- it's now possible to use other OpenCLIP model checkpoints through the `--model-name` (or `-M`) and `--checkpoint-name` (or `-C`) arguments (list of models and checkpoints [here](https://github.com/mlfoundations/open_clip/blob/main/docs/openclip_results.csv))
- default model has been changed to `ViT-B-32 | datacomp_xl_s13b_b90k`, due to its superior performance with the exact same number of parameters
- feature vector size is loaded from model configuration
- removed possibly redundant code from `model.py`
