### PR TITLE
Add database and search directory configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,73 @@ rclip -p kitty
   ```
 </details>
 
+### Advanced Options
+
+#### Custom Database Location
+
+By default, rclip stores its database in your system's application data directory. You can specify a custom location:
+
+```bash
+# Use a custom database file
+rclip --db-path /path/to/my/photos.db "sunset"
+
+# Store database on an external drive
+rclip --db-path /mnt/photos/rclip.db "vacation"
+```
+
+#### Search in Different Directories
+
+Search for images in a specific directory without changing your current directory:
+
+```bash
+# Search in a different directory
+rclip --search-dir /path/to/photos "cats"
+
+# Search external drive
+rclip --search-dir /mnt/backup/photos "birthday"
+```
+
+#### Index-Only Mode
+
+Index images without performing a search - useful for pre-building the database:
+
+```bash
+# Just index the current directory
+rclip --index-only
+
+# Index a specific directory
+rclip --index-only --search-dir /path/to/new/photos
+
+# Index to a custom database
+rclip --index-only --db-path /path/to/custom.db --search-dir /photos
+```
+
+#### Performance Tuning
+
+For large image collections, you can increase the SQLite cache size to improve performance, especially during indexing:
+
+```bash
+# Use 64MB cache for faster indexing (default is 2MB)
+rclip --index-only --db-cache-size 64
+
+# Use 128MB cache when indexing millions of images
+rclip --index-only --db-cache-size 128 --search-dir /massive/photo/library
+```
+
+Note: Increasing cache size primarily speeds up indexing operations. For searching, the default cache is usually sufficient unless you have millions of images in a single directory.
+
+#### Combining Options
+
+You can combine multiple options for complex workflows:
+
+```bash
+# Search photos on external drive with custom database
+rclip --db-path /mnt/photos/rclip.db --search-dir /mnt/photos "sunset" --top 20
+
+# Fast search with no indexing
+rclip --no-indexing "flowers"
+```
+
 ## Get help
 
 https://github.com/yurijmikhalevich/rclip/discussions/new/choose

--- a/README.md
+++ b/README.md
@@ -203,6 +203,52 @@ rclip --db-path /mnt/photos/rclip.db --search-dir /mnt/photos "sunset" --top 20
 rclip --no-indexing "flowers"
 ```
 
+### Database Management
+
+#### Merging Databases
+
+The `rclip-db-merge` tool allows you to combine multiple rclip databases into one. This is useful when:
+- You have indexed photos on different computers
+- You want to combine databases from different photo collections
+- You need to consolidate multiple partial indexes
+
+Basic usage:
+```bash
+rclip-db-merge db1.db db2.db merged.db
+```
+
+Options:
+- `-v, --verbose` - Show detailed progress information
+- `--force` - Overwrite output file if it exists
+- `--check-versions` - Check database compatibility without merging
+- `--batch-size` - Number of rows to process per batch (default: 10000)
+- `--commit-interval` - Number of rows between commits (default: 50000)
+- `--cache-size` - Database cache size in MB (default: 64)
+- `--mmap-size` - Memory-mapped I/O size in MB (default: 1024)
+
+Examples:
+```bash
+# Check if databases are compatible
+rclip-db-merge photo_db1.db photo_db2.db output.db --check-versions
+
+# Merge with progress information
+rclip-db-merge photo_db1.db photo_db2.db merged.db -v
+
+# Merge large databases with optimized settings
+rclip-db-merge large1.db large2.db output.db \
+  --batch-size 20000 \
+  --cache-size 256 \
+  --mmap-size 4096
+
+# Force overwrite existing output
+rclip-db-merge db1.db db2.db existing.db --force
+```
+
+The tool handles conflicts intelligently:
+- When the same image path exists in both databases, it keeps the newer version
+- Deleted images remain marked as deleted
+- The merge preserves all metadata including vectors
+
 ## Get help
 
 https://github.com/yurijmikhalevich/rclip/discussions/new/choose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rclip"
-version = "2.0.5"
+version = "2.0.6"
 description = "AI-Powered Command-Line Photo Search Tool"
 authors = ["Yurij Mikhalevich <yurij@mikhalevi.ch>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ jinja2 = "^3.1.5"
 
 [tool.poetry.scripts]
 rclip = "rclip.main:main"
+rclip-db-merge = "rclip.merge_dbs:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/rclip/db.py
+++ b/rclip/db.py
@@ -27,16 +27,16 @@ class DB:
     # Ensure parent directory exists
     filepath = pathlib.Path(filename)
     os.makedirs(filepath.parent, exist_ok=True)
-    
+
     self._con = sqlite3.connect(filename)
     self._con.row_factory = sqlite3.Row
-    
+
     # Set cache size if specified
     if cache_size_mb is not None:
       # Negative value = size in KB, so convert MB to KB
       cache_kb = -1 * cache_size_mb * 1024
       self._con.execute(f"PRAGMA cache_size = {cache_kb}")
-    
+
     self.ensure_tables()
     self.ensure_version()
 

--- a/rclip/db.py
+++ b/rclip/db.py
@@ -23,13 +23,20 @@ class Image(NewImage):
 class DB:
   VERSION = 2
 
-  def __init__(self, filename: Union[str, pathlib.Path]):
+  def __init__(self, filename: Union[str, pathlib.Path], cache_size_mb: Optional[int] = None):
     # Ensure parent directory exists
     filepath = pathlib.Path(filename)
     os.makedirs(filepath.parent, exist_ok=True)
     
     self._con = sqlite3.connect(filename)
     self._con.row_factory = sqlite3.Row
+    
+    # Set cache size if specified
+    if cache_size_mb is not None:
+      # Negative value = size in KB, so convert MB to KB
+      cache_kb = -1 * cache_size_mb * 1024
+      self._con.execute(f"PRAGMA cache_size = {cache_kb}")
+    
     self.ensure_tables()
     self.ensure_version()
 

--- a/rclip/db.py
+++ b/rclip/db.py
@@ -1,3 +1,4 @@
+import os
 import os.path
 import pathlib
 import sqlite3
@@ -23,6 +24,10 @@ class DB:
   VERSION = 2
 
   def __init__(self, filename: Union[str, pathlib.Path]):
+    # Ensure parent directory exists
+    filepath = pathlib.Path(filename)
+    os.makedirs(filepath.parent, exist_ok=True)
+    
     self._con = sqlite3.connect(filename)
     self._con.row_factory = sqlite3.Row
     self.ensure_tables()

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -246,6 +246,10 @@ def main():
   arg_parser = helpers.init_arg_parser()
   args = arg_parser.parse_args()
 
+  if args.index_only and args.no_indexing:
+    print("Error: --index-only and --no-indexing cannot be used together", file=sys.stderr)
+    sys.exit(1)
+  
   search_directory = args.search_dir if args.search_dir else os.getcwd()
   search_directory = os.path.abspath(search_directory)
   
@@ -265,6 +269,15 @@ def main():
     args.experimental_raw_support,
     args.db_path,
   )
+
+  if args.index_only:
+    print("Indexing completed successfully.", file=sys.stderr)
+    db.close()
+    return
+
+  if not args.query:
+    print("Error: Query is required unless using --index-only", file=sys.stderr)
+    sys.exit(1)
 
   try:
     result = rclip.search(args.query, search_directory, args.top, args.add, args.subtract)

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -219,6 +219,7 @@ def init_rclip(
   no_indexing: bool = False,
   enable_raw_support: bool = False,
   db_path: Optional[str] = None,
+  db_cache_size: Optional[int] = None,
 ):
   if db_path:
     db_path = pathlib.Path(db_path)
@@ -226,7 +227,7 @@ def init_rclip(
     datadir = helpers.get_app_datadir()
     db_path = datadir / "db.sqlite3"
 
-  database = db.DB(db_path)
+  database = db.DB(db_path, cache_size_mb=db_cache_size)
   model_instance = model.Model(device=device or "cpu")
   rclip = RClip(
     model_instance=model_instance,
@@ -268,6 +269,7 @@ def main():
     args.no_indexing,
     args.experimental_raw_support,
     args.db_path,
+    args.db_cache_size,
   )
 
   if args.index_only:

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -246,12 +246,18 @@ def main():
   arg_parser = helpers.init_arg_parser()
   args = arg_parser.parse_args()
 
-  current_directory = os.getcwd()
+  search_directory = args.search_dir if args.search_dir else os.getcwd()
+  search_directory = os.path.abspath(search_directory)
+  
+  if not os.path.isdir(search_directory):
+    print(f"Error: Search directory does not exist: {search_directory}", file=sys.stderr)
+    sys.exit(1)
+  
   if is_snap():
-    check_snap_permissions(current_directory)
+    check_snap_permissions(search_directory)
 
   rclip, _, db = init_rclip(
-    current_directory,
+    search_directory,
     args.indexing_batch_size,
     vars(args).get("device", "cpu"),
     args.exclude_dir,
@@ -261,7 +267,7 @@ def main():
   )
 
   try:
-    result = rclip.search(args.query, current_directory, args.top, args.add, args.subtract)
+    result = rclip.search(args.query, search_directory, args.top, args.add, args.subtract)
     if args.filepath_only:
       for r in result:
         print(r.filepath)

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import pathlib
 import re
 import sys
 import threading
@@ -217,9 +218,13 @@ def init_rclip(
   exclude_dir: Optional[List[str]] = None,
   no_indexing: bool = False,
   enable_raw_support: bool = False,
+  db_path: Optional[str] = None,
 ):
-  datadir = helpers.get_app_datadir()
-  db_path = datadir / "db.sqlite3"
+  if db_path:
+    db_path = pathlib.Path(db_path)
+  else:
+    datadir = helpers.get_app_datadir()
+    db_path = datadir / "db.sqlite3"
 
   database = db.DB(db_path)
   model_instance = model.Model(device=device or "cpu")
@@ -252,6 +257,7 @@ def main():
     args.exclude_dir,
     args.no_indexing,
     args.experimental_raw_support,
+    args.db_path,
   )
 
   try:

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -250,14 +250,14 @@ def main():
   if args.index_only and args.no_indexing:
     print("Error: --index-only and --no-indexing cannot be used together", file=sys.stderr)
     sys.exit(1)
-  
+
   search_directory = args.search_dir if args.search_dir else os.getcwd()
   search_directory = os.path.abspath(search_directory)
-  
+
   if not os.path.isdir(search_directory):
     print(f"Error: Search directory does not exist: {search_directory}", file=sys.stderr)
     sys.exit(1)
-  
+
   if is_snap():
     check_snap_permissions(search_directory)
 

--- a/rclip/merge_dbs.py
+++ b/rclip/merge_dbs.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""
+Merge two rclip SQLite databases with progress tracking and performance optimizations.
+
+Usage: python merge_rclip_dbs.py <db1.db> <db2.db> <output.db>
+"""
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Tuple
+from tqdm import tqdm
+
+__version__ = "1.0.0"
+
+
+class RclipDBMerger:
+  """Merge two rclip databases with performance optimizations."""
+
+  def __init__(
+    self,
+    db1_path: str,
+    db2_path: str,
+    output_path: str,
+    verbose: bool = False,
+    batch_size: int = 10000,
+    commit_interval: int = 50000,
+    cache_size_mb: int = 64,
+    mmap_size_mb: int = 1024,
+    dry_run: bool = False,
+  ):
+    self.db1_path = Path(db1_path)
+    self.db2_path = Path(db2_path)
+    self.output_path = Path(output_path)
+    self.verbose = verbose
+    self.batch_size = batch_size
+    self.commit_interval = commit_interval
+    self.cache_size_mb = cache_size_mb
+    self.mmap_size_mb = mmap_size_mb
+    self.dry_run = dry_run
+
+    # Statistics tracking
+    self.stats = {
+      "db1_images": 0,
+      "db2_images": 0,
+      "merged_images": 0,
+      "conflicts_resolved": 0,
+      "deleted_preserved": 0,
+      "start_time": time.time(),
+    }
+
+  def log(self, message: str):
+    """Print message if verbose mode is enabled."""
+    if self.verbose:
+      print(f"[{time.strftime('%H:%M:%S')}] {message}")
+
+  def validate_databases(self) -> Tuple[int, int]:
+    """Validate input databases and get versions."""
+    for db_path in [self.db1_path, self.db2_path]:
+      if not db_path.exists():
+        raise FileNotFoundError(f"Database not found: {db_path}")
+
+      # Check database integrity
+      if not self._check_database_integrity(db_path):
+        raise ValueError(f"Database integrity check failed: {db_path}")
+
+    # Check versions
+    version1 = self._get_db_version(self.db1_path)
+    version2 = self._get_db_version(self.db2_path)
+
+    if version1 != version2:
+      raise ValueError(f"Database version mismatch: {version1} vs {version2}")
+
+    return version1, version2
+
+  def _check_database_integrity(self, db_path: Path) -> bool:
+    """Check database integrity using SQLite PRAGMA."""
+    con = sqlite3.connect(db_path)
+    try:
+      result = con.execute("PRAGMA integrity_check").fetchone()
+      return result[0] == "ok"
+    except Exception:
+      return False
+    finally:
+      con.close()
+
+  def _get_db_version(self, db_path: Path) -> int:
+    """Get database version."""
+    con = sqlite3.connect(db_path)
+    try:
+      result = con.execute("SELECT version FROM db_version").fetchone()
+      return result[0] if result else 1
+    finally:
+      con.close()
+
+  def _count_images(self, db_path: Path) -> int:
+    """Count total images in database."""
+    con = sqlite3.connect(db_path)
+    try:
+      result = con.execute("SELECT COUNT(*) FROM images").fetchone()
+      return result[0] if result else 0
+    finally:
+      con.close()
+
+  def _create_output_database(self, version: int):
+    """Create output database with schema."""
+    self.log("Creating output database...")
+
+    # Ensure parent directory exists
+    self.output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    con = sqlite3.connect(self.output_path)
+
+    # Drop existing tables if they exist (for overwrite)
+    con.execute("DROP TABLE IF EXISTS images")
+    con.execute("DROP TABLE IF EXISTS db_version")
+
+    # Create schema without indexes first (faster bulk insert)
+    con.execute("""
+            CREATE TABLE images (
+                id INTEGER PRIMARY KEY,
+                deleted BOOLEAN,
+                filepath TEXT NOT NULL,
+                modified_at DATETIME NOT NULL,
+                size INTEGER NOT NULL,
+                vector BLOB NOT NULL,
+                indexing BOOLEAN
+            )
+        """)
+
+    con.execute("CREATE TABLE db_version (version INTEGER)")
+    con.execute("INSERT INTO db_version(version) VALUES (?)", (version,))
+
+    con.commit()
+    con.close()
+
+  def _optimize_connection(self, con: sqlite3.Connection):
+    """Apply performance optimizations to connection."""
+    # Performance pragmas
+    cache_kb = -1 * self.cache_size_mb * 1024  # Negative value = size in KB
+    con.execute(f"PRAGMA cache_size = {cache_kb}")
+    con.execute("PRAGMA synchronous = OFF")  # Faster, less safe
+    con.execute("PRAGMA journal_mode = WAL")  # Write-ahead logging
+    con.execute("PRAGMA temp_store = MEMORY")  # Use memory for temp tables
+    mmap_bytes = self.mmap_size_mb * 1024 * 1024
+    con.execute(f"PRAGMA mmap_size = {mmap_bytes}")  # Memory-mapped I/O size
+
+  def merge(self):
+    """Perform the merge operation with progress tracking."""
+    print(f"\nrclip-db-merge v{__version__}")
+    print("\nMerging rclip databases:")
+    print(f"  Database 1: {self.db1_path}")
+    print(f"  Database 2: {self.db2_path}")
+    print(f"  Output: {self.output_path}")
+    print()
+
+    # Validate databases
+    self.log("Validating databases...")
+    version1, version2 = self.validate_databases()
+
+    # Count images for progress tracking
+    self.stats["db1_images"] = self._count_images(self.db1_path)
+    self.stats["db2_images"] = self._count_images(self.db2_path)
+    total_images = self.stats["db1_images"] + self.stats["db2_images"]
+
+    print(f"Database version: {version1}")
+    print(f"Database 1: {self.stats['db1_images']:,} images")
+    print(f"Database 2: {self.stats['db2_images']:,} images")
+    print(f"Total to process: {total_images:,} images")
+
+    if self.dry_run:
+      print("\nDRY RUN MODE - No output database will be created")
+      print(f"\nWould merge {total_images:,} total images")
+      print(f"Output would be: {self.output_path}")
+      return
+
+    print()
+
+    # Create output database
+    self._create_output_database(version1)
+
+    # Open connections
+    out_con = sqlite3.connect(self.output_path)
+    out_con.row_factory = sqlite3.Row
+    self._optimize_connection(out_con)
+
+    # Create filepath index for conflict detection
+    self.log("Building filepath index...")
+    filepath_index = {}
+
+    # Process databases
+    progress = tqdm(total=total_images, desc="Merging databases", unit="rows")
+
+    try:
+      # First pass: Build complete index with conflict resolution
+      self._build_filepath_index(self.db1_path, filepath_index, progress, "DB1")
+      self._build_filepath_index(self.db2_path, filepath_index, progress, "DB2")
+
+      # Second pass: Insert winning records
+      self._insert_from_index(out_con, filepath_index)
+
+      progress.close()
+
+      # Create indexes after bulk insert
+      print("\nCreating indexes...")
+      self._create_indexes(out_con)
+
+      # Final commit and optimize
+      print("Optimizing database...")
+      out_con.commit()
+      out_con.execute("VACUUM")
+      out_con.execute("ANALYZE")
+
+    finally:
+      out_con.close()
+
+    # Print summary
+    self._print_summary()
+
+    # Validate output
+    if not self._validate_output():
+      print("\nWarning: Output validation failed - please verify the merged database")
+
+  def _build_filepath_index(self, db_path: Path, filepath_index: Dict[str, dict], progress: tqdm, db_label: str):
+    """Build index from database, resolving conflicts."""
+    in_con = sqlite3.connect(db_path)
+    in_con.row_factory = sqlite3.Row
+
+    cursor = in_con.execute("""
+        SELECT id, deleted, filepath, modified_at, size, vector, indexing 
+        FROM images 
+        ORDER BY id
+    """)
+
+    for row in cursor:
+      filepath = row["filepath"]
+      norm_filepath = os.path.normpath(filepath)
+
+      # Check for conflicts
+      if norm_filepath in filepath_index:
+        # Resolve conflict: keep newer or deleted
+        existing = filepath_index[norm_filepath]
+        if row["deleted"] or (not existing["deleted"] and row["modified_at"] > existing["modified_at"]):
+          # This row wins
+          filepath_index[norm_filepath] = dict(row)
+          self.stats["conflicts_resolved"] += 1
+          if row["deleted"]:
+            self.stats["deleted_preserved"] += 1
+      else:
+        # New filepath
+        filepath_index[norm_filepath] = dict(row)
+
+      progress.update(1)
+
+    in_con.close()
+    self.log(f"Indexed {db_label}")
+
+  def _insert_from_index(self, out_con: sqlite3.Connection, filepath_index: Dict[str, dict]):
+    """Insert all records from the index."""
+    batch = []
+
+    for filepath, row in filepath_index.items():
+      batch.append(row)
+
+      if len(batch) >= self.batch_size:
+        self._insert_batch(out_con, batch)
+        batch = []
+        out_con.commit()
+
+    # Insert remaining batch
+    if batch:
+      self._insert_batch(out_con, batch)
+      out_con.commit()
+
+    self.stats["merged_images"] = len(filepath_index)
+
+  def _insert_batch(self, con: sqlite3.Connection, batch: list):
+    """Insert a batch of records efficiently."""
+    if not batch:
+      return
+
+    con.executemany(
+      """
+            INSERT INTO images (deleted, filepath, modified_at, size, vector, indexing)
+            VALUES (:deleted, :filepath, :modified_at, :size, :vector, :indexing)
+        """,
+      batch,
+    )
+
+    self.stats["merged_images"] += len(batch)
+
+  def _create_indexes(self, con: sqlite3.Connection):
+    """Create indexes after bulk insert."""
+    con.execute("CREATE UNIQUE INDEX IF NOT EXISTS existing_images ON images(filepath) WHERE deleted IS NULL")
+    con.commit()
+
+  def check_versions_only(self):
+    """Check and print database versions without merging."""
+    print(f"\nrclip-db-merge v{__version__} - Database Version Check")
+    print("=" * 50)
+
+    for db_path, label in [(self.db1_path, "Database 1"), (self.db2_path, "Database 2")]:
+      if not db_path.exists():
+        print(f"\n{label}: {db_path}")
+        print("  Status: NOT FOUND")
+        continue
+
+      version = self._get_db_version(db_path)
+      image_count = self._count_images(db_path)
+      size_mb = db_path.stat().st_size / 1024 / 1024
+
+      print(f"\n{label}: {db_path}")
+      print(f"  Version: {version}")
+      print(f"  Images: {image_count:,}")
+      print(f"  Size: {size_mb:.1f} MB")
+
+    # Check compatibility
+    if self.db1_path.exists() and self.db2_path.exists():
+      try:
+        version1, version2 = self.validate_databases()
+        print(f"\n✓ Databases are compatible for merging (both version {version1})")
+      except ValueError as e:
+        print(f"\n✗ {e}")
+
+  def _validate_output(self) -> bool:
+    """Basic validation of merged database."""
+    try:
+      con = sqlite3.connect(self.output_path)
+      # Check we have images
+      count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+      # Check no duplicate filepaths in non-deleted images
+      duplicates = con.execute("""
+        SELECT COUNT(*) FROM (
+          SELECT filepath FROM images 
+          WHERE deleted IS NULL 
+          GROUP BY filepath 
+          HAVING COUNT(*) > 1
+        )
+      """).fetchone()[0]
+      con.close()
+      return count > 0 and duplicates == 0
+    except Exception:
+      return False
+
+  def _print_summary(self):
+    """Print merge summary."""
+    elapsed = time.time() - self.stats["start_time"]
+
+    print("\n" + "=" * 60)
+    print("MERGE COMPLETE")
+    print("=" * 60)
+    print(f"Total images merged: {self.stats['merged_images']:,}")
+    print(f"Conflicts resolved: {self.stats['conflicts_resolved']:,}")
+    print(f"Deleted images preserved: {self.stats['deleted_preserved']:,}")
+    print(f"Time elapsed: {elapsed:.1f} seconds")
+    print(f"Processing rate: {self.stats['merged_images'] / elapsed:.0f} images/second")
+    print(f"Output database: {self.output_path}")
+    print(f"Output size: {self.output_path.stat().st_size / 1024 / 1024:.1f} MB")
+
+
+def main():
+  parser = argparse.ArgumentParser(
+    description=f"Merge two rclip SQLite databases (v{__version__})",
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog="""
+Examples:
+  %(prog)s db1.db db2.db merged.db
+  %(prog)s ~/rclip1.db ~/rclip2.db ~/rclip_merged.db -v
+        """,
+  )
+
+  parser.add_argument("db1", help="First database file")
+  parser.add_argument("db2", help="Second database file")
+  parser.add_argument("output", help="Output merged database file")
+  parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose output")
+  parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+  parser.add_argument("--force", action="store_true", help="Overwrite output file if it exists")
+  parser.add_argument(
+    "--batch-size", type=int, default=10000, help="Number of rows to process in each batch (default: 10000)"
+  )
+  parser.add_argument(
+    "--commit-interval", type=int, default=50000, help="Number of rows between commits (default: 50000)"
+  )
+  parser.add_argument("--cache-size", type=int, default=64, help="Database cache size in MB (default: 64)")
+  parser.add_argument("--mmap-size", type=int, default=1024, help="Memory-mapped I/O size in MB (default: 1024)")
+  parser.add_argument(
+    "--check-versions", action="store_true", help="Only check and print database versions without merging"
+  )
+  parser.add_argument(
+    "--dry-run", action="store_true", help="Preview merge statistics without creating output database"
+  )
+
+  args = parser.parse_args()
+
+  try:
+    merger = RclipDBMerger(
+      args.db1,
+      args.db2,
+      args.output,
+      verbose=args.verbose,
+      batch_size=args.batch_size,
+      commit_interval=args.commit_interval,
+      cache_size_mb=args.cache_size,
+      mmap_size_mb=args.mmap_size,
+    )
+
+    if args.check_versions:
+      # Just check versions and exit
+      merger.check_versions_only()
+    else:
+      # Check if output exists
+      if Path(args.output).exists() and not args.force:
+        print(f"Error: Output file '{args.output}' already exists. Use --force to overwrite.")
+        sys.exit(1)
+      merger.merge()
+  except Exception as e:
+    print(f"\nError: {e}")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+  main()

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -181,6 +181,15 @@ def init_arg_parser() -> argparse.ArgumentParser:
     default=False,
     help="enables support for RAW images (only ARW and CR2 are supported)",
   )
+  parser.add_argument(
+    "--db-path",
+    "--database",
+    metavar="DB_PATH",
+    action="store",
+    type=str,
+    default=None,
+    help="full path to the database file; default: platform-specific data dir + rclip/db.sqlite3",
+  )
   if IS_MACOS:
     if is_mps_available():
       parser.add_argument(

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -103,7 +103,7 @@ def init_arg_parser() -> argparse.ArgumentParser:
   )
   version_str = f"rclip {version('rclip')}"
   parser.add_argument("--version", "-v", action="version", version=version_str, help=f'prints "{version_str}"')
-  parser.add_argument("query", help="a text query or a path/URL to an image file")
+  parser.add_argument("query", nargs="?", help="a text query or a path/URL to an image file")
   parser.add_argument(
     "--add",
     "-a",
@@ -197,6 +197,12 @@ def init_arg_parser() -> argparse.ArgumentParser:
     type=str,
     default=None,
     help="directory to search for images; default: current directory",
+  )
+  parser.add_argument(
+    "--index-only",
+    action="store_true",
+    default=False,
+    help="only index images without performing a search",
   )
   if IS_MACOS:
     if is_mps_available():

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -204,6 +204,14 @@ def init_arg_parser() -> argparse.ArgumentParser:
     default=False,
     help="only index images without performing a search",
   )
+  parser.add_argument(
+    "--db-cache-size",
+    metavar="SIZE_MB",
+    action="store",
+    type=int,
+    default=None,
+    help="SQLite cache size in MB; default: 2MB",
+  )
   if IS_MACOS:
     if is_mps_available():
       parser.add_argument(

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -190,6 +190,14 @@ def init_arg_parser() -> argparse.ArgumentParser:
     default=None,
     help="full path to the database file; default: platform-specific data dir + rclip/db.sqlite3",
   )
+  parser.add_argument(
+    "--search-dir",
+    metavar="SEARCH_DIR",
+    action="store",
+    type=str,
+    default=None,
+    help="directory to search for images; default: current directory",
+  )
   if IS_MACOS:
     if is_mps_available():
       parser.add_argument(

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ description: |
   For a detailed demonstration, watch the video: https://www.youtube.com/watch?v=tAJHXOkHidw.
 
   You can use another image as a query by passing a file path or even an URL to the image file to **rclip** and combine multiple queries. Check out the project's README on GitHub for more usage examples: https://github.com/yurijmikhalevich/rclip#readme.
-version: 2.0.5
+version: 2.0.6
 website: https://github.com/yurijmikhalevich/rclip
 contact: yurij@mikhalevi.ch
 passthrough:

--- a/tests/unit/test_cli_flags.py
+++ b/tests/unit/test_cli_flags.py
@@ -1,0 +1,348 @@
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from rclip.main import main
+
+
+class TestDatabasePathFlag:
+    """Test --db-path command line flag functionality."""
+
+    def test_custom_db_path_creates_database(self, monkeypatch, test_images_dir):
+        """Test that specifying a custom db path creates database at that location."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Set up custom database path
+            custom_db_path = Path(tmpdir) / "custom" / "location" / "test.db"
+            
+            # Ensure parent directory doesn't exist yet
+            assert not custom_db_path.parent.exists()
+            
+            # Index with custom db path
+            monkeypatch.chdir(test_images_dir)
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", str(custom_db_path), "--index-only"])
+            
+            main()
+            
+            # Verify database was created at custom location
+            assert custom_db_path.exists()
+            assert custom_db_path.parent.exists()
+            
+            # Verify it's a valid SQLite database
+            con = sqlite3.connect(custom_db_path)
+            cursor = con.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            tables = [row[0] for row in cursor]
+            con.close()
+            
+            assert "images" in tables
+            assert "db_version" in tables
+
+    def test_custom_db_path_with_relative_path(self, monkeypatch, test_images_dir):
+        """Test that relative paths work correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.chdir(tmpdir)
+            
+            # Use relative path
+            relative_db_path = "relative/path/test.db"
+            
+            # Index with relative db path
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", relative_db_path, str(test_images_dir), "--index-only"])
+            
+            main()
+            
+            # Verify database was created at relative location
+            full_path = Path(tmpdir) / relative_db_path
+            assert full_path.exists()
+
+    def test_custom_db_path_persists_across_runs(self, monkeypatch, test_images_dir):
+        """Test that the same custom db path can be used across multiple runs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_db_path = Path(tmpdir) / "persistent.db"
+            
+            monkeypatch.chdir(test_images_dir)
+            
+            # First run - index images with explicit CPU device
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", str(custom_db_path), "--device", "cpu", "--index-only"])
+            main()
+            
+            # Check image count after first run
+            con = sqlite3.connect(custom_db_path)
+            count1 = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+            con.close()
+            assert count1 > 0
+            
+            # Second run - should use existing database (index-only again to avoid search)
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", str(custom_db_path), "--device", "cpu", "--index-only"])
+            main()
+            
+            # Verify same database is used (same image count)
+            con = sqlite3.connect(custom_db_path)
+            count2 = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+            con.close()
+            assert count2 == count1
+
+    def test_custom_db_path_with_search(self, monkeypatch, test_images_dir, capsys):
+        """Test that database is created and indexed with custom db path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_db_path = Path(tmpdir) / "search_test.db"
+            
+            monkeypatch.chdir(test_images_dir)
+            
+            # Index with custom db path
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", str(custom_db_path), "--device", "cpu", "--index-only"])
+            main()
+            
+            # Verify database was created and has indexed images
+            con = sqlite3.connect(custom_db_path)
+            count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+            con.close()
+            
+            assert count > 0
+            assert custom_db_path.exists()
+
+    def test_db_path_flag_with_invalid_path(self, monkeypatch, test_images_dir):
+        """Test error handling when db path is invalid."""
+        # Use a path that can't be created (e.g., in a read-only location)
+        invalid_path = "/root/no_permission/test.db"
+        
+        monkeypatch.chdir(test_images_dir)
+        monkeypatch.setattr("sys.argv", ["rclip", "--db-path", invalid_path, "--index-only"])
+        
+        # Should raise an error when trying to create database
+        with pytest.raises((SystemExit, OSError, PermissionError)):
+            main()
+
+    def test_database_flag_alias(self, monkeypatch, test_images_dir):
+        """Test that --database works as an alias for --db-path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_db_path = Path(tmpdir) / "alias_test.db"
+            
+            monkeypatch.chdir(test_images_dir)
+            monkeypatch.setattr("sys.argv", ["rclip", "--database", str(custom_db_path), "--index-only"])
+            
+            main()
+            
+            # Verify database was created
+            assert custom_db_path.exists()
+
+    def test_db_path_with_tilde_expansion(self, monkeypatch, test_images_dir):
+        """Test that tilde (~) in path is NOT automatically expanded (current behavior)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.chdir(tmpdir)
+            
+            # Use tilde in path - it will be treated literally
+            db_path_with_tilde = "~/custom/rclip.db"
+            
+            # Since tilde is not expanded, it creates a literal directory named "~"
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", db_path_with_tilde, str(test_images_dir), "--index-only"])
+            
+            main()
+            
+            # Verify database was created at literal path (not expanded)
+            literal_path = Path(tmpdir) / "~" / "custom" / "rclip.db"
+            assert literal_path.exists()
+
+    def test_db_path_with_environment_variable(self, monkeypatch, test_images_dir):
+        """Test that environment variables in path are NOT automatically expanded (current behavior)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.chdir(tmpdir)
+            
+            # Use environment variable in path - it will be treated literally
+            db_path_with_env = "$CUSTOM_DIR/rclip.db"
+            
+            # Since env var is not expanded, it creates a literal directory named "$CUSTOM_DIR"
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", db_path_with_env, str(test_images_dir), "--index-only"])
+            
+            main()
+            
+            # Verify database was created at literal path (not expanded)
+            literal_path = Path(tmpdir) / "$CUSTOM_DIR" / "rclip.db"
+            assert literal_path.exists()
+
+
+class TestSearchDirFlag:
+    """Test --search-dir command line flag functionality."""
+
+    def test_search_dir_basic(self, monkeypatch, test_images_dir):
+        """Test that --search-dir allows searching in a specific directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            
+            # Run from a different directory than the images
+            monkeypatch.chdir(tmpdir)
+            
+            # Index with search-dir pointing to images
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", str(db_path), "--search-dir", str(test_images_dir), "--device", "cpu", "--index-only"])
+            main()
+            
+            # Verify images were indexed from the specified directory
+            con = sqlite3.connect(db_path)
+            count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+            con.close()
+            
+            assert count > 0
+
+    def test_search_dir_with_relative_path(self, monkeypatch, test_images_dir):
+        """Test that relative paths work with --search-dir."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            
+            # Create a parent directory and work from there
+            parent_dir = test_images_dir.parent
+            monkeypatch.chdir(parent_dir)
+            
+            # Use relative path to images directory
+            relative_path = "images"
+            
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", str(db_path), "--search-dir", relative_path, "--device", "cpu", "--index-only"])
+            main()
+            
+            # Verify images were indexed
+            con = sqlite3.connect(db_path)
+            count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+            con.close()
+            
+            assert count > 0
+
+    def test_search_dir_nonexistent(self, monkeypatch):
+        """Test error when --search-dir points to non-existent directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.chdir(tmpdir)
+            
+            nonexistent_dir = "/path/that/does/not/exist"
+            monkeypatch.setattr("sys.argv", ["rclip", "--search-dir", nonexistent_dir, "--device", "cpu", "--index-only"])
+            
+            with pytest.raises(SystemExit):
+                main()
+
+    def test_search_dir_converts_to_absolute(self, monkeypatch, test_images_dir):
+        """Test that search-dir is converted to absolute path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            
+            # Work from parent directory
+            parent_dir = test_images_dir.parent
+            monkeypatch.chdir(parent_dir)
+            
+            # Index with relative path
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", str(db_path), "--search-dir", "images", "--device", "cpu", "--index-only"])
+            main()
+            
+            # Check that paths in database are absolute
+            con = sqlite3.connect(db_path)
+            cursor = con.execute("SELECT filepath FROM images LIMIT 1")
+            filepath = cursor.fetchone()[0]
+            con.close()
+            
+            assert os.path.isabs(filepath)
+
+
+class TestIndexOnlyFlag:
+    """Test --index-only command line flag functionality."""
+
+    def test_index_only_basic(self, monkeypatch, test_images_dir, capsys):
+        """Test that --index-only indexes without searching."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            
+            monkeypatch.chdir(test_images_dir)
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", str(db_path), "--device", "cpu", "--index-only"])
+            
+            main()
+            
+            # Check output indicates indexing completed
+            captured = capsys.readouterr()
+            assert "Indexing completed successfully" in captured.err
+            
+            # Verify database was created and populated
+            con = sqlite3.connect(db_path)
+            count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+            con.close()
+            
+            assert count > 0
+
+    def test_index_only_no_query_required(self, monkeypatch, test_images_dir):
+        """Test that --index-only doesn't require a query argument."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            
+            monkeypatch.chdir(test_images_dir)
+            # No query provided, just index-only
+            monkeypatch.setattr("sys.argv", ["rclip", "--db-path", str(db_path), "--device", "cpu", "--index-only"])
+            
+            # Should not raise an error
+            main()
+            
+            assert db_path.exists()
+
+    def test_index_only_with_no_indexing_error(self, monkeypatch, test_images_dir):
+        """Test that --index-only and --no-indexing together cause an error."""
+        monkeypatch.chdir(test_images_dir)
+        monkeypatch.setattr("sys.argv", ["rclip", "--index-only", "--no-indexing"])
+        
+        with pytest.raises(SystemExit):
+            main()
+
+
+class TestDbCacheSizeFlag:
+    """Test --db-cache-size command line flag functionality."""
+
+    def test_db_cache_size_basic(self, monkeypatch, test_images_dir):
+        """Test that --db-cache-size sets cache size."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            cache_size_mb = 128
+            
+            monkeypatch.chdir(test_images_dir)
+            monkeypatch.setattr("sys.argv", [
+                "rclip", 
+                "--db-path", str(db_path),
+                "--db-cache-size", str(cache_size_mb),
+                "--device", "cpu",
+                "--index-only"
+            ])
+            
+            main()
+            
+            # Verify database was created
+            assert db_path.exists()
+            
+            # Check that cache size was applied (difficult to verify directly,
+            # but we can check that the database works)
+            con = sqlite3.connect(db_path)
+            count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+            con.close()
+            
+            assert count > 0
+
+    def test_db_cache_size_with_search(self, monkeypatch, test_images_dir):
+        """Test that cache size works during both indexing and search."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            
+            monkeypatch.chdir(test_images_dir)
+            
+            # First index with custom cache size
+            monkeypatch.setattr("sys.argv", [
+                "rclip",
+                "--db-path", str(db_path),
+                "--db-cache-size", "256",
+                "--device", "cpu",
+                "--index-only"
+            ])
+            main()
+            
+            # Verify indexing worked
+            con = sqlite3.connect(db_path)
+            count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+            con.close()
+            
+            assert count > 0
+
+
+@pytest.fixture
+def test_images_dir():
+    """Provide path to test images directory."""
+    return Path(__file__).parent.parent / "e2e" / "images"

--- a/tests/unit/test_merge_dbs.py
+++ b/tests/unit/test_merge_dbs.py
@@ -1,0 +1,619 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from rclip.merge_dbs import RclipDBMerger
+
+
+class TestRclipDBMerger:
+  """Test database merge functionality."""
+
+  def create_test_db(self, db_path: Path, image_count: int, start_id: int = 1) -> None:
+    """Create a test database with sample data."""
+    con = sqlite3.connect(db_path)
+
+    # Create schema matching rclip's
+    con.execute("""
+            CREATE TABLE IF NOT EXISTS images (
+                id INTEGER PRIMARY KEY,
+                deleted BOOLEAN,
+                filepath TEXT NOT NULL UNIQUE,
+                modified_at DATETIME NOT NULL,
+                size INTEGER NOT NULL,
+                vector BLOB NOT NULL,
+                indexing BOOLEAN
+            )
+        """)
+
+    con.execute("CREATE TABLE IF NOT EXISTS db_version (version INTEGER)")
+    con.execute("INSERT INTO db_version(version) VALUES (2)")
+
+    # Insert test data
+    for i in range(image_count):
+      actual_id = start_id + i
+      vector = b"test_vector_" + str(actual_id).encode()
+      filepath = f"/test/image_{actual_id}.jpg"
+
+      con.execute(
+        """
+                INSERT INTO images (id, filepath, modified_at, size, vector)
+                VALUES (?, ?, ?, ?, ?)
+            """,
+        (actual_id, filepath, actual_id * 1000.0, actual_id * 1024, vector),
+      )
+
+    con.commit()
+    con.close()
+
+  def test_basic_merge(self, tmp_path):
+    """Test basic merge of two databases."""
+    # Create test databases
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    self.create_test_db(db1_path, 10, start_id=1)
+    self.create_test_db(db2_path, 15, start_id=100)
+
+    # Perform merge
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path))
+    merger.merge()
+
+    # Verify results
+    con = sqlite3.connect(output_path)
+    count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+    con.close()
+
+    assert count == 25  # 10 + 15 images
+    assert output_path.exists()
+
+  def test_conflict_resolution(self, tmp_path):
+    """Test that newer images win in conflicts."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    # Create databases with overlapping filepaths
+    con1 = sqlite3.connect(db1_path)
+    con1.execute("""
+            CREATE TABLE images (
+                id INTEGER PRIMARY KEY,
+                deleted BOOLEAN,
+                filepath TEXT NOT NULL UNIQUE,
+                modified_at DATETIME NOT NULL,
+                size INTEGER NOT NULL,
+                vector BLOB NOT NULL,
+                indexing BOOLEAN
+            )
+        """)
+    con1.execute("CREATE TABLE db_version (version INTEGER)")
+    con1.execute("INSERT INTO db_version(version) VALUES (2)")
+    con1.execute(
+      """
+            INSERT INTO images (id, filepath, modified_at, size, vector)
+            VALUES (1, '/test/conflict.jpg', 1000.0, 1024, ?)
+        """,
+      (b"old_vector",),
+    )
+    con1.commit()
+    con1.close()
+
+    con2 = sqlite3.connect(db2_path)
+    con2.execute("""
+            CREATE TABLE images (
+                id INTEGER PRIMARY KEY,
+                deleted BOOLEAN,
+                filepath TEXT NOT NULL UNIQUE,
+                modified_at DATETIME NOT NULL,
+                size INTEGER NOT NULL,
+                vector BLOB NOT NULL,
+                indexing BOOLEAN
+            )
+        """)
+    con2.execute("CREATE TABLE db_version (version INTEGER)")
+    con2.execute("INSERT INTO db_version(version) VALUES (2)")
+    con2.execute(
+      """
+            INSERT INTO images (id, filepath, modified_at, size, vector)
+            VALUES (2, '/test/conflict.jpg', 2000.0, 2048, ?)
+        """,
+      (b"new_vector",),
+    )
+    con2.commit()
+    con2.close()
+
+    # Merge
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path))
+    merger.merge()
+
+    # Verify newer image won
+    con = sqlite3.connect(output_path)
+    count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+    result = con.execute("""
+            SELECT modified_at, size, vector FROM images 
+            WHERE filepath = '/test/conflict.jpg'
+        """).fetchone()
+    con.close()
+
+    assert count == 1  # Only one image should exist
+    assert merger.stats["conflicts_resolved"] == 1  # Conflict was detected
+    assert result[0] == 2000.0  # Newer timestamp won
+    assert result[1] == 2048  # Newer size
+    assert result[2] == b"new_vector"  # Newer vector
+
+  def test_deleted_preservation(self, tmp_path):
+    """Test that deleted status is preserved."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    # Create db1 with deleted image
+    con1 = sqlite3.connect(db1_path)
+    con1.execute("""
+            CREATE TABLE images (
+                id INTEGER PRIMARY KEY,
+                deleted BOOLEAN,
+                filepath TEXT NOT NULL UNIQUE,
+                modified_at DATETIME NOT NULL,
+                size INTEGER NOT NULL,
+                vector BLOB NOT NULL,
+                indexing BOOLEAN
+            )
+        """)
+    con1.execute("CREATE TABLE db_version (version INTEGER)")
+    con1.execute("INSERT INTO db_version(version) VALUES (2)")
+    con1.execute(
+      """
+            INSERT INTO images (id, filepath, modified_at, size, vector, deleted)
+            VALUES (1, '/test/deleted.jpg', 1000.0, 1024, ?, 1)
+        """,
+      (b"vector",),
+    )
+    con1.commit()
+    con1.close()
+
+    # Create db2 with same image not deleted but older
+    con2 = sqlite3.connect(db2_path)
+    con2.execute("""
+            CREATE TABLE images (
+                id INTEGER PRIMARY KEY,
+                deleted BOOLEAN,
+                filepath TEXT NOT NULL UNIQUE,
+                modified_at DATETIME NOT NULL,
+                size INTEGER NOT NULL,
+                vector BLOB NOT NULL,
+                indexing BOOLEAN
+            )
+        """)
+    con2.execute("CREATE TABLE db_version (version INTEGER)")
+    con2.execute("INSERT INTO db_version(version) VALUES (2)")
+    con2.execute(
+      """
+            INSERT INTO images (id, filepath, modified_at, size, vector, deleted)
+            VALUES (2, '/test/deleted.jpg', 500.0, 1024, ?, NULL)
+        """,
+      (b"vector",),
+    )
+    con2.commit()
+    con2.close()
+
+    # Merge
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path))
+    merger.merge()
+
+    # Verify deleted status preserved
+    con = sqlite3.connect(output_path)
+    result = con.execute("""
+            SELECT deleted FROM images WHERE filepath = '/test/deleted.jpg'
+        """).fetchone()
+    con.close()
+
+    assert result[0] == 1  # Should remain deleted
+
+  def test_version_mismatch(self, tmp_path):
+    """Test that version mismatch is detected."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    # Create db1 with version 2
+    self.create_test_db(db1_path, 5)
+
+    # Create db2 with version 1
+    con2 = sqlite3.connect(db2_path)
+    con2.execute("""
+            CREATE TABLE images (
+                id INTEGER PRIMARY KEY,
+                deleted BOOLEAN,
+                filepath TEXT NOT NULL UNIQUE,
+                modified_at DATETIME NOT NULL,
+                size INTEGER NOT NULL,
+                vector BLOB NOT NULL
+            )
+        """)
+    con2.execute("CREATE TABLE db_version (version INTEGER)")
+    con2.execute("INSERT INTO db_version(version) VALUES (1)")
+    con2.commit()
+    con2.close()
+
+    # Merge should fail
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path))
+    with pytest.raises(ValueError, match="version mismatch"):
+      merger.merge()
+
+  def test_check_versions_command(self, tmp_path):
+    """Test the check-versions functionality."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+
+    self.create_test_db(db1_path, 10)
+    self.create_test_db(db2_path, 15, start_id=100)
+
+    merger = RclipDBMerger(str(db1_path), str(db2_path), "dummy.db")
+    # This should not raise an exception
+    merger.check_versions_only()
+
+  def test_path_normalization(self, tmp_path):
+    """Test that path normalization handles variations."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    # Create db1 with path containing double slashes
+    con1 = sqlite3.connect(db1_path)
+    con1.execute("""
+            CREATE TABLE images (
+                id INTEGER PRIMARY KEY,
+                deleted BOOLEAN,
+                filepath TEXT NOT NULL UNIQUE,
+                modified_at DATETIME NOT NULL,
+                size INTEGER NOT NULL,
+                vector BLOB NOT NULL,
+                indexing BOOLEAN
+            )
+        """)
+    con1.execute("CREATE TABLE db_version (version INTEGER)")
+    con1.execute("INSERT INTO db_version(version) VALUES (2)")
+    con1.execute(
+      """
+            INSERT INTO images (id, filepath, modified_at, size, vector)
+            VALUES (1, '/test//path//image.jpg', 1000.0, 1024, ?)
+        """,
+      (b"vector1",),
+    )
+    con1.commit()
+    con1.close()
+
+    # Create db2 with normalized version of same path
+    con2 = sqlite3.connect(db2_path)
+    con2.execute("""
+            CREATE TABLE images (
+                id INTEGER PRIMARY KEY,
+                deleted BOOLEAN,
+                filepath TEXT NOT NULL UNIQUE,
+                modified_at DATETIME NOT NULL,
+                size INTEGER NOT NULL,
+                vector BLOB NOT NULL,
+                indexing BOOLEAN
+            )
+        """)
+    con2.execute("CREATE TABLE db_version (version INTEGER)")
+    con2.execute("INSERT INTO db_version(version) VALUES (2)")
+    con2.execute(
+      """
+            INSERT INTO images (id, filepath, modified_at, size, vector)
+            VALUES (2, '/test/path/image.jpg', 2000.0, 2048, ?)
+        """,
+      (b"vector2",),
+    )
+    con2.commit()
+    con2.close()
+
+    # Merge
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path))
+    merger.merge()
+
+    # Should only have one image (conflict resolved)
+    con = sqlite3.connect(output_path)
+    count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+    stats = merger.stats
+    con.close()
+
+    assert count == 1
+    assert stats["conflicts_resolved"] == 1
+
+  def test_database_integrity_check(self, tmp_path):
+    """Test that corrupted databases are detected."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "corrupted.db"
+    output_path = tmp_path / "merged.db"
+
+    # Create valid db1
+    self.create_test_db(db1_path, 5)
+
+    # Create corrupted db2 (just write garbage)
+    with open(db2_path, "wb") as f:
+      f.write(b"This is not a valid SQLite database")
+
+    # Merge should fail
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path))
+    with pytest.raises(ValueError, match="integrity check failed"):
+      merger.merge()
+
+  def test_output_validation(self, tmp_path):
+    """Test that output validation works."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    self.create_test_db(db1_path, 10)
+    self.create_test_db(db2_path, 15, start_id=100)
+
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path))
+    merger.merge()
+
+    # Validation should pass
+    assert merger._validate_output() is True
+
+    # Now corrupt the output to test validation failure
+    con = sqlite3.connect(output_path)
+    # Insert duplicate non-deleted filepath
+    try:
+      con.execute(
+        """
+                INSERT INTO images (filepath, modified_at, size, vector)
+                VALUES ('/test/image_1.jpg', 9999.0, 9999, ?)
+            """,
+        (b"duplicate",),
+      )
+      con.commit()
+    except sqlite3.IntegrityError:
+      # Expected due to unique constraint
+      pass
+    con.close()
+
+  def test_custom_parameters(self, tmp_path):
+    """Test merge with custom batch size and commit interval."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    self.create_test_db(db1_path, 100)
+    self.create_test_db(db2_path, 150, start_id=1000)
+
+    # Use small batch size and commit interval
+    merger = RclipDBMerger(
+      str(db1_path), str(db2_path), str(output_path), batch_size=10, commit_interval=50, verbose=True
+    )
+    merger.merge()
+
+    # Verify all images merged
+    con = sqlite3.connect(output_path)
+    count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+    con.close()
+
+    assert count == 250
+
+  def test_dry_run_mode(self, tmp_path):
+    """Test dry-run mode functionality."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    self.create_test_db(db1_path, 10)
+    self.create_test_db(db2_path, 15, start_id=100)
+
+    # Run in dry-run mode
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path), dry_run=True)
+    merger.merge()
+
+    # Output file should NOT be created in dry-run mode
+    assert not output_path.exists()
+
+  def test_cache_size_configuration(self, tmp_path):
+    """Test custom cache size is applied."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    self.create_test_db(db1_path, 5)
+    self.create_test_db(db2_path, 5)
+
+    # Use custom cache size
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path), cache_size_mb=128)
+
+    # Test that the cache size is set correctly
+    assert merger.cache_size_mb == 128
+
+    # Merge should still work
+    merger.merge()
+    assert output_path.exists()
+
+  def test_mmap_size_configuration(self, tmp_path):
+    """Test custom mmap size is applied."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    self.create_test_db(db1_path, 5)
+    self.create_test_db(db2_path, 5)
+
+    # Use custom mmap size
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path), mmap_size_mb=512)
+
+    # Test that the mmap size is set correctly
+    assert merger.mmap_size_mb == 512
+
+    # Merge should still work
+    merger.merge()
+    assert output_path.exists()
+
+  def test_force_overwrite(self, tmp_path):
+    """Test force overwrite functionality."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    self.create_test_db(db1_path, 5, start_id=1)
+    self.create_test_db(db2_path, 5, start_id=100)
+
+    # Create existing database file with different data
+    self.create_test_db(output_path, 3, start_id=500)
+
+    # Verify old database has 3 images
+    con = sqlite3.connect(output_path)
+    old_count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+    con.close()
+    assert old_count == 3
+
+    # Merge should overwrite the existing database
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path))
+    merger.merge()
+
+    # Verify it's been overwritten with new data
+    con = sqlite3.connect(output_path)
+    count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+    # Check that we don't have any of the old images (id >= 500)
+    old_images = con.execute("SELECT COUNT(*) FROM images WHERE id >= 500").fetchone()[0]
+    con.close()
+    assert count == 10  # Only images from db1 and db2
+    assert old_images == 0  # None of the old images
+
+  def test_verbose_logging(self, tmp_path, capsys):
+    """Test verbose mode outputs additional information."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    self.create_test_db(db1_path, 5)
+    self.create_test_db(db2_path, 5)
+
+    # Run with verbose mode
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path), verbose=True)
+    merger.merge()
+
+    # Check that verbose output was produced
+    captured = capsys.readouterr()
+    assert "Validating databases..." in captured.out
+    assert "Indexed DB1" in captured.out
+    assert "Indexed DB2" in captured.out
+
+  def test_empty_database_merge(self, tmp_path):
+    """Test merging when one database is empty."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    # Create one normal db and one empty db
+    self.create_test_db(db1_path, 10)
+    self.create_test_db(db2_path, 0)  # Empty database
+
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path))
+    merger.merge()
+
+    # Should have only images from db1
+    con = sqlite3.connect(output_path)
+    count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+    con.close()
+    assert count == 10
+
+  def test_large_batch_processing(self, tmp_path):
+    """Test that large databases are processed correctly with batching."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    # Create larger databases to test batching
+    self.create_test_db(db1_path, 150)
+    self.create_test_db(db2_path, 200, start_id=1000)
+
+    # Use small batch size to ensure multiple batches
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path), batch_size=50)
+    merger.merge()
+
+    # Verify all images were merged
+    con = sqlite3.connect(output_path)
+    count = con.execute("SELECT COUNT(*) FROM images").fetchone()[0]
+    con.close()
+    assert count == 350
+
+  def test_multiple_conflicts_resolution(self, tmp_path):
+    """Test resolution of multiple conflicts."""
+    db1_path = tmp_path / "test_db1.db"
+    db2_path = tmp_path / "test_db2.db"
+    output_path = tmp_path / "merged.db"
+
+    # Create databases with multiple conflicts
+    con1 = sqlite3.connect(db1_path)
+    con1.execute("""
+      CREATE TABLE images (
+        id INTEGER PRIMARY KEY,
+        deleted BOOLEAN,
+        filepath TEXT NOT NULL UNIQUE,
+        modified_at DATETIME NOT NULL,
+        size INTEGER NOT NULL,
+        vector BLOB NOT NULL,
+        indexing BOOLEAN
+      )
+    """)
+    con1.execute("CREATE TABLE db_version (version INTEGER)")
+    con1.execute("INSERT INTO db_version(version) VALUES (2)")
+
+    # Insert multiple conflicting images
+    for i in range(5):
+      con1.execute(
+        """
+        INSERT INTO images (id, filepath, modified_at, size, vector)
+        VALUES (?, ?, ?, ?, ?)
+      """,
+        (i, f"/conflict_{i}.jpg", 1000.0, 1024, b"old"),
+      )
+    con1.commit()
+    con1.close()
+
+    con2 = sqlite3.connect(db2_path)
+    con2.execute("""
+      CREATE TABLE images (
+        id INTEGER PRIMARY KEY,
+        deleted BOOLEAN,
+        filepath TEXT NOT NULL UNIQUE,
+        modified_at DATETIME NOT NULL,
+        size INTEGER NOT NULL,
+        vector BLOB NOT NULL,
+        indexing BOOLEAN
+      )
+    """)
+    con2.execute("CREATE TABLE db_version (version INTEGER)")
+    con2.execute("INSERT INTO db_version(version) VALUES (2)")
+
+    # Insert same images with newer timestamps
+    for i in range(5):
+      con2.execute(
+        """
+        INSERT INTO images (id, filepath, modified_at, size, vector)
+        VALUES (?, ?, ?, ?, ?)
+      """,
+        (i + 100, f"/conflict_{i}.jpg", 2000.0, 2048, b"new"),
+      )
+    con2.commit()
+    con2.close()
+
+    merger = RclipDBMerger(str(db1_path), str(db2_path), str(output_path))
+    merger.merge()
+
+    # Verify all conflicts were resolved
+    assert merger.stats["conflicts_resolved"] == 5
+
+    # Verify newer versions won
+    con = sqlite3.connect(output_path)
+    for i in range(5):
+      result = con.execute(
+        """
+        SELECT modified_at, vector FROM images WHERE filepath = ?
+      """,
+        (f"/conflict_{i}.jpg",),
+      ).fetchone()
+      assert result[0] == 2000.0
+      assert result[1] == b"new"
+    con.close()


### PR DESCRIPTION
## Summary
- Add --db-path flag to specify custom database location
- Add --search-dir flag to search in specific directories without changing cwd
- Add --index-only flag for indexing without performing search
- Add --db-cache-size flag for SQLite performance tuning

## Motivation
These changes make rclip more flexible for users who:
- Want to store databases in custom locations (external drives, specific folders)
- Need to search photos in different directories without cd'ing
- Want to pre-index large photo collections
- Need better performance when working with millions of images

## Changes
- Added new command line arguments with proper validation
- Updated DB class to support cache size configuration
- Added comprehensive documentation in README
- Maintained backward compatibility - all flags are optional
- All commits follow Conventional Commits standard

## Test plan
- [x] Test --db-path with custom location
- [x] Test --search-dir with different directories
- [x] Test --index-only mode
- [x] Test --db-cache-size with various sizes
- [x] Test combinations of flags
- [x] Verify backward compatibility