### PR TITLE
chore: deprecate Intel-based Macs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,9 +48,6 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11', '3.12']
-        # macos-13 is amd64, macos-15 is arm64
-        # skipping macos-13 here because newer versions of torch aren't being built for amd64 macOS anymore
-        # builds for amd64 macOS are being tested during brew release
         os: [ubuntu-22.04, macos-15, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-latest-stable-release.yaml
+++ b/.github/workflows/test-latest-stable-release.yaml
@@ -49,8 +49,8 @@ jobs:
         # FIXME: the test fails on linuxbrew because it rclip from linuxbrew
         # produces a slightly different output; maybe, because we built pytorch
         # slightly differently for linuxbrew
-        # os: [ubuntu-22.04, macos-13, macos-15]
-        os: [macos-13, macos-15]
+        # os: [ubuntu-22.04, macos-15]
+        os: [macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-latest-stable-release.yaml
+++ b/.github/workflows/test-latest-stable-release.yaml
@@ -22,8 +22,6 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11', '3.12']
-        # macos-13 is amd64, macos-14 is arm64
-        # skipping macos-13 here because newer versions of torch aren't being built for amd64 macOS anymore
         os: [ubuntu-22.04, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -17,9 +17,6 @@ jobs:
     strategy:
       matrix:
         python: ['3.10', '3.11', '3.12']
-        # macos-13 is amd64, macos-14 is arm64
-        # skipping macos-13 here because newer versions of torch aren't being built for amd64 macOS anymore
-        # the brew builds for amd64 macOS are being validated during brew release
         os: [ubuntu-22.04, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ sudo snap install rclip
 brew install yurijmikhalevich/tap/rclip
 ```
 
+**Note:** we only support rclip and provide prebuilt binaries for Apple Silicon (arm64). You may still try building brew rclip for Intel-based Macs yourself or try an alternative installation option below.
+
 <details>
   <summary>Alternative option (<code>pip</code>)</summary>
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sudo snap install rclip
 brew install yurijmikhalevich/tap/rclip
 ```
 
-**Note:** We only support and provide prebuilt binaries for Apple Silicon (arm64). You may try building brew rclip for Intel-based Macs yourself or try an alternative installation option below.
+**Note:** We only support and provide prebuilt bottles for Apple Silicon (arm64). You may try building brew rclip for Intel-based Macs yourself or try an alternative installation option below.
 
 <details>
   <summary>Alternative option (<code>pip</code>)</summary>

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sudo snap install rclip
 brew install yurijmikhalevich/tap/rclip
 ```
 
-**Note:** We only support rclip and provide prebuilt binaries for Apple Silicon (arm64). You may try building brew rclip for Intel-based Macs yourself or try an alternative installation option below.
+**Note:** We only support and provide prebuilt binaries for Apple Silicon (arm64). You may try building brew rclip for Intel-based Macs yourself or try an alternative installation option below.
 
 <details>
   <summary>Alternative option (<code>pip</code>)</summary>

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ sudo snap install rclip
 brew install yurijmikhalevich/tap/rclip
 ```
 
-**Note:** we only support rclip and provide prebuilt binaries for Apple Silicon (arm64). You may still try building brew rclip for Intel-based Macs yourself or try an alternative installation option below.
+**Note:** We only support rclip and provide prebuilt binaries for Apple Silicon (arm64). You may try building brew rclip for Intel-based Macs yourself or try an alternative installation option below.
 
 <details>
   <summary>Alternative option (<code>pip</code>)</summary>


### PR DESCRIPTION
## How does this PR impact the user?

Users of Intel-based Macs may experience issues installing or using rclip, and our CI will no longer catch them.

## Description

- [x] stop running daily e2e tests on Intel-based Macs
- [x] update README to say that we only support Apple Silicon Macs

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
