### PR TITLE
fix(snap): perm error message mention both symlink path and resolved path

### DIFF
--- a/rclip/main.py
+++ b/rclip/main.py
@@ -236,9 +236,10 @@ def init_rclip(
       rclip.ensure_index(working_directory)
     except PermissionError as e:
       if is_snap() and e.filename is not None and os.path.islink(e.filename):
+        symlink_path = e.filename
         realpath = os.path.realpath(e.filename)
 
-        print(f"\n{get_snap_permission_error(realpath, is_current_directory=False)}\n")
+        print(f"\n{get_snap_permission_error(realpath, symlink_path, is_current_directory=False)}\n")
         sys.exit(1)
       raise
 

--- a/rclip/utils/snap.py
+++ b/rclip/utils/snap.py
@@ -6,7 +6,11 @@ def is_snap():
   return bool(os.getenv("SNAP"))
 
 
-def get_snap_permission_error(directory: str, is_current_directory: bool = False) -> str:
+def get_snap_permission_error(
+  directory: str, 
+  symlink_path: str | None,
+  is_current_directory: bool = False,
+) -> str:
   homedir = os.getenv("SNAP_REAL_HOME")
   if not homedir:
     return (
@@ -16,9 +20,15 @@ def get_snap_permission_error(directory: str, is_current_directory: bool = False
     )
 
   directory_str = "the current directory" if is_current_directory else directory
+  
+  if symlink_path and symlink_path != directory:
+    path_info = f"symlink: {symlink_path} which points to realpath: {directory_str}"
+  else:
+    path_info = directory_str
+  
   if directory == homedir or directory.startswith(homedir + os.sep):
     return (
-      f"rclip doesn't have access to {directory_str}."
+      f"rclip doesn't have access to {path_info}."
       " You can resolve this issue by running:"
       "\n\n\tsudo snap connect rclip:home\n\n"
       "This command will grant rclip the necessary access to the home directory."
@@ -26,7 +36,7 @@ def get_snap_permission_error(directory: str, is_current_directory: bool = False
     )
   if directory == "/media" or directory.startswith("/media" + os.sep):
     return (
-      f"rclip doesn't have access to {directory_str}."
+      f"rclip doesn't have access to {path_info}."
       " You can resolve this issue by running:"
       "\n\n\tsudo snap connect rclip:removable-media\n\n"
       'This command will grant rclip the necessary access to the "/media" directory.'
@@ -42,8 +52,17 @@ def get_snap_permission_error(directory: str, is_current_directory: bool = False
 
 
 def check_snap_permissions(directory: str, is_current_directory: bool = False):
+    
   try:
     any(os.scandir(directory))
   except PermissionError:
-    print(get_snap_permission_error(directory, is_current_directory))
+    symlink_path = None
+    realpath = directory
+    
+    if os.path.islink(directory):
+      symlink_path = directory
+      realpath = os.path.realpath(directory)
+        
+    print(get_snap_permission_error(realpath, symlink_path, is_current_directory))
     sys.exit(1)
+  


### PR DESCRIPTION
## How does this PR impact the user?
This PR adds more descriptive information (`symlink_path` and `resolved_path`) for users encountering permission errors with Snap, especially when symlinks are involved.

## Description
1. Updates `check_snap_permissions()` to get the `symlink_path` if the directory path is symlink and pass it to the `get_snap_permission_error()`
2. Updates `get_snap_permission_error()` to print the `symlink_path` and `resolved_path` information for the users

## Checklist
- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
