### PR TITLE
fix: error on redirecting output on unicode file paths

### DIFF
--- a/rclip/main.py
+++ b/rclip/main.py
@@ -16,7 +16,6 @@ from rclip.utils.preview import preview
 from rclip.utils.snap import check_snap_permissions, is_snap, get_snap_permission_error
 from rclip.utils import helpers
 
-sys.stdout = open(sys.stdout.fileno(), 'w', encoding='utf-8', closefd=False)
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
@@ -264,6 +263,8 @@ def main():
   )
 
   try:
+    if sys.stdout.isatty() is False:
+      sys.stdout = open(sys.stdout.fileno(), 'w', encoding='utf-8-sig', closefd=False)
     result = rclip.search(args.query, current_directory, args.top, args.add, args.subtract)
     if args.filepath_only:
       for r in result:

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -16,6 +16,7 @@ from rclip.utils.preview import preview
 from rclip.utils.snap import check_snap_permissions, is_snap, get_snap_permission_error
 from rclip.utils import helpers
 
+sys.stdout = open(sys.stdout.fileno(), 'w', encoding='utf-8', closefd=False)
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 


### PR DESCRIPTION
## How does this PR impact the user?

Before: When redirecting stdout to a file with unicode filepaths, the program would raise an execption and crash

<img width="1098" height="289" alt="image" src="https://github.com/user-attachments/assets/75708abf-d7c2-419b-8c8f-faa86fa8c45c" />

After: The program successfully writes output to file and displays characters correctly

<img width="1084" height="200" alt="image" src="https://github.com/user-attachments/assets/b76853fe-36f0-4587-aab2-3888a23460d1" />


## Description

Before outputting the scores and file paths of detected images, the program will first check if it is outputting to console. If it is not (therefore it is outputting to a file) it will change the encoding method of stdout to `utf-8-sig` which encodes unicode correctly and writes to the specified file using this encoding.

## Limitations

Have not tested impact on MacOS and Linux, however this should be none to low.

## Checklist

- [x] my PR is focused and contains one holistic change
- [x] I have added screenshots or screen recordings to show the changes
