### PR TITLE
ci(windows release build): fix CodeSignTool download URL

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -246,7 +246,7 @@ jobs:
       - name: Sign MSI
         run: |
           mkdir signed
-          Invoke-WebRequest -URI https://ee2cc1f8.rocketcdn.me/wp-content/uploads/2023/11/CodeSignTool-v1.2.7-windows.zip -OutFile CodeSignTool.zip
+          Invoke-WebRequest -URI https://d1smxttentwwqu.cloudfront.net/wp-content/uploads/2023/11/CodeSignTool-v1.2.7-windows.zip -OutFile CodeSignTool.zip
           if ( ( Get-FileHash -Algorithm SHA256 CodeSignTool.zip ).Hash -ne 'AC9CDBFF6D482DBC1107ABC8789570F57ECF85773332BBA466CB3E00CE0BB841' ) { throw 'hash does not match' }
           Expand-Archive -Path CodeSignTool.zip -DestinationPath .
           cd CodeSignTool-v1.2.7-windows


### PR DESCRIPTION
## How does this PR impact the user?

We will be able to release new versions of rclip for Windows.

## Description

- [x] update the CodeSignTool URL

## Limitations

n/a

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
