### PR TITLE
chore(ci): reuse the model cache when running e2e tests in CI to speed them up

### DIFF
--- a/rclip/model.py
+++ b/rclip/model.py
@@ -32,16 +32,16 @@ class Model:
 
   def __init__(self, device: str = "cpu"):
     self._device = device
+    self._model_cache_dir = helpers.get_model_cache_dir()
 
     self._model_var = None
     self._model_text_var = None
     self._preprocess_var = None
     self._tokenizer_var = None
 
-    self._text_model_path = helpers.get_app_datadir() / f"{self._model_name}_{self._checkpoint_name}_text.pth"
-    self._text_model_version_path = (
-      helpers.get_app_datadir() / f"{self._model_name}_{self._checkpoint_name}_text.version"
-    )
+    model_datadir = self._model_cache_dir or helpers.get_app_datadir()
+    self._text_model_path = model_datadir / f"{self._model_name}_{self._checkpoint_name}_text.pth"
+    self._text_model_version_path = model_datadir / f"{self._model_name}_{self._checkpoint_name}_text.version"
 
   @property
   def _tokenizer(self):
@@ -54,6 +54,7 @@ class Model:
       self._model_name,
       pretrained=self._checkpoint_name,
       device=self._device,
+      cache_dir=str(self._model_cache_dir) if self._model_cache_dir else None,
     )
     self._model_text_var = None
 

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -52,6 +52,16 @@ def get_app_datadir() -> pathlib.Path:
   return app_datadir
 
 
+def get_model_cache_dir() -> pathlib.Path | None:
+  model_cache_dir = os.getenv("RCLIP_MODEL_CACHE_DIR")
+  if not model_cache_dir:
+    return None
+
+  model_cache_path = pathlib.Path(model_cache_dir)
+  os.makedirs(model_cache_path, exist_ok=True)
+  return model_cache_path
+
+
 def positive_int_arg_type(arg: str) -> int:
   arg_int = int(arg)
   if arg_int < 1:

--- a/tests/e2e/test_rclip.py
+++ b/tests/e2e/test_rclip.py
@@ -39,6 +39,12 @@ def test_dir_with_unicode_filenames():
   return Path(__file__).parent / "images unicode"
 
 
+@pytest.fixture(scope="session")
+def shared_model_cache_dir():
+  with tempfile.TemporaryDirectory() as tmpdirname:
+    yield tmpdirname
+
+
 def _assert_output_snapshot(
   images_dir: Path, request: pytest.FixtureRequest, capfd: pytest.CaptureFixture[str], encoding: str | None = None
 ):
@@ -92,14 +98,19 @@ def assert_output_snapshot_unicode_filepaths(
   _assert_output_snapshot(test_dir_with_unicode_filenames, request, capfd, "utf-8-sig")
 
 
-def execute_query(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, *args: str):
+def execute_query(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str, *args: str):
   with tempfile.TemporaryDirectory() as tmpdirname:
     run_system_rclip = os.getenv("RCLIP_TEST_RUN_SYSTEM_RCLIP")
     if run_system_rclip:
       completed_run = subprocess.run(
         ["rclip", *args],
         cwd=test_images_dir,
-        env={**os.environ, "RCLIP_DATADIR": tmpdirname, "RCLIP_TEST_RUN_SYSTEM_RCLIP": ""},
+        env={
+          **os.environ,
+          "RCLIP_DATADIR": tmpdirname,
+          "RCLIP_MODEL_CACHE_DIR": shared_model_cache_dir,
+          "RCLIP_TEST_RUN_SYSTEM_RCLIP": "",
+        },
       )
       if completed_run.returncode != 0:
         raise SystemExit(completed_run.returncode)
@@ -107,125 +118,146 @@ def execute_query(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, *args:
       from rclip.main import main
 
       monkeypatch.setenv("RCLIP_DATADIR", tmpdirname)
+      monkeypatch.setenv("RCLIP_MODEL_CACHE_DIR", shared_model_cache_dir)
       monkeypatch.chdir(test_images_dir)
       set_argv(*args)
       main()
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_search(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
-  execute_query(test_images_dir, monkeypatch, "kitty")
+def test_search(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
+  execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, "kitty")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_search_webp(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
+def test_search_webp(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
   # this test result snapshot should contain a webp image
-  execute_query(test_images_dir, monkeypatch, "tree")
+  execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, "tree")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_search_png(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
+def test_search_png(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
   # this test result snapshot should contain a png image
-  execute_query(test_images_dir, monkeypatch, "boats on a lake")
+  execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, "boats on a lake")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_search_heic(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
+def test_search_heic(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
   # this test result snapshot should contain a heic image
-  execute_query(test_images_dir, monkeypatch, "bee")
+  execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, "bee")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_repeated_searches_should_be_the_same(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
-  execute_query(test_images_dir, monkeypatch, "boats on a lake")
-  execute_query(test_images_dir, monkeypatch, "boats on a lake")
-  execute_query(test_images_dir, monkeypatch, "boats on a lake")
+def test_repeated_searches_should_be_the_same(
+  test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str
+):
+  execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, "boats on a lake")
+  execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, "boats on a lake")
+  execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, "boats on a lake")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_search_by_image(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
-  execute_query(test_images_dir, monkeypatch, str(test_images_dir / "cat.jpg"))
+def test_search_by_image(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
+  execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, str(test_images_dir / "cat.jpg"))
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_search_by_image_from_url(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
+def test_search_by_image_from_url(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
   execute_query(
     test_images_dir,
     monkeypatch,
+    shared_model_cache_dir,
     "https://raw.githubusercontent.com/yurijmikhalevich/rclip/5630d6279ee94f0cad823777433d7fbeb921d19e/tests/e2e/images/cat.jpg",  # noqa
   )
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_search_by_non_existing_file(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
+def test_search_by_non_existing_file(
+  test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str
+):
   with pytest.raises(SystemExit):
-    execute_query(test_images_dir, monkeypatch, "./non-existing-file.jpg")
+    execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, "./non-existing-file.jpg")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_search_by_not_an_image(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
+def test_search_by_not_an_image(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
   with pytest.raises(SystemExit):
-    execute_query(test_images_dir, monkeypatch, str(test_images_dir / "not-an-image.txt"))
+    execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, str(test_images_dir / "not-an-image.txt"))
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_add_queries(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
-  execute_query(test_images_dir, monkeypatch, "kitty", "--add", "puppy", "-a", "roof", "+", "fence")
+def test_add_queries(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
+  execute_query(
+    test_images_dir, monkeypatch, shared_model_cache_dir, "kitty", "--add", "puppy", "-a", "roof", "+", "fence"
+  )
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_subtract_queries(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
-  execute_query(test_images_dir, monkeypatch, "kitty", "--subtract", "puppy", "-s", "roof", "-", "fence")
+def test_subtract_queries(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
+  execute_query(
+    test_images_dir, monkeypatch, shared_model_cache_dir, "kitty", "--subtract", "puppy", "-s", "roof", "-", "fence"
+  )
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_add_and_subtract_queries(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
-  execute_query(test_images_dir, monkeypatch, "kitty", "+", "roof", "-", "fence")
+def test_add_and_subtract_queries(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
+  execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, "kitty", "+", "roof", "-", "fence")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_query_multipliers(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
-  execute_query(test_images_dir, monkeypatch, "kitty", "+", "2:night", "-", "0.5:fence")
+def test_query_multipliers(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
+  execute_query(test_images_dir, monkeypatch, shared_model_cache_dir, "kitty", "+", "2:night", "-", "0.5:fence")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_combine_text_query_with_image_query(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
-  execute_query(test_images_dir, monkeypatch, str(test_images_dir / "cat.jpg"), "-", "3:cat", "+", "2:bee")
+def test_combine_text_query_with_image_query(
+  test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str
+):
+  execute_query(
+    test_images_dir, monkeypatch, shared_model_cache_dir, str(test_images_dir / "cat.jpg"), "-", "3:cat", "+", "2:bee"
+  )
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_combine_image_query_with_text_query(test_images_dir: Path, monkeypatch: pytest.MonkeyPatch):
-  execute_query(test_images_dir, monkeypatch, "kitty", "-", str(test_images_dir / "cat.jpg"), "+", "1.5:bee")
+def test_combine_image_query_with_text_query(
+  test_images_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str
+):
+  execute_query(
+    test_images_dir, monkeypatch, shared_model_cache_dir, "kitty", "-", str(test_images_dir / "cat.jpg"), "+", "1.5:bee"
+  )
 
 
 @pytest.mark.usefixtures("assert_output_snapshot")
-def test_search_empty_dir(test_empty_dir: Path, monkeypatch: pytest.MonkeyPatch):
-  execute_query(test_empty_dir, monkeypatch, "kitty")
+def test_search_empty_dir(test_empty_dir: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str):
+  execute_query(test_empty_dir, monkeypatch, shared_model_cache_dir, "kitty")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot_nested_directories")
 def test_search_dir_with_multiple_nested_directories(
   test_dir_with_nested_directories: Path,
   monkeypatch: pytest.MonkeyPatch,
+  shared_model_cache_dir: str,
 ):
-  execute_query(test_dir_with_nested_directories, monkeypatch, "kitty")
+  execute_query(test_dir_with_nested_directories, monkeypatch, shared_model_cache_dir, "kitty")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot_nested_directories")
 def test_search_dir_with_deeply_nested_directories(
   test_dir_with_nested_directories: Path,
   monkeypatch: pytest.MonkeyPatch,
+  shared_model_cache_dir: str,
 ):
   # output should contain a nested path to the bee image
-  execute_query(test_dir_with_nested_directories, monkeypatch, "bee")
+  execute_query(test_dir_with_nested_directories, monkeypatch, shared_model_cache_dir, "bee")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot_nested_directories")
 def test_handles_addition_and_deletion_of_images(
   test_dir_with_nested_directories: Path,
   monkeypatch: pytest.MonkeyPatch,
+  shared_model_cache_dir: str,
 ):
-  execute_query(test_dir_with_nested_directories, monkeypatch, "bee")
+  execute_query(test_dir_with_nested_directories, monkeypatch, shared_model_cache_dir, "bee")
 
   bee_image_path = test_dir_with_nested_directories / "misc" / "bees" / "bee.jpg"
   assert bee_image_path.exists()
@@ -236,13 +268,13 @@ def test_handles_addition_and_deletion_of_images(
     bee_image_path_copy.write_bytes(bee_image_path.read_bytes())
 
     # should include bee image copy in the output snapshot
-    execute_query(test_dir_with_nested_directories, monkeypatch, "bee")
+    execute_query(test_dir_with_nested_directories, monkeypatch, shared_model_cache_dir, "bee")
 
     # delete bee image copy
     bee_image_path_copy.unlink()
 
     # should not include bee image copy in the output snapshot
-    execute_query(test_dir_with_nested_directories, monkeypatch, "bee")
+    execute_query(test_dir_with_nested_directories, monkeypatch, shared_model_cache_dir, "bee")
 
   finally:
     bee_image_path_copy.unlink(missing_ok=True)
@@ -252,38 +284,50 @@ def test_handles_addition_and_deletion_of_images(
 def test_ignores_raw_files_if_raw_support_is_disabled(
   test_dir_with_raw_images: Path,
   monkeypatch: pytest.MonkeyPatch,
+  shared_model_cache_dir: str,
 ):
   # output should not contain any raw images
-  execute_query(test_dir_with_raw_images, monkeypatch, "boat on a lake")
+  execute_query(test_dir_with_raw_images, monkeypatch, shared_model_cache_dir, "boat on a lake")
 
 
 @pytest.mark.usefixtures("assert_output_snapshot_raw_images")
 def test_ignores_raw_if_there_is_a_png_named_the_same_way_in_the_same_dir(
   test_dir_with_raw_images: Path,
   monkeypatch: pytest.MonkeyPatch,
+  shared_model_cache_dir: str,
 ):
   # output should not contain "boat on a lake.ARW" image
-  execute_query(test_dir_with_raw_images, monkeypatch, "--experimental-raw-support", "boat on a lake")
+  execute_query(
+    test_dir_with_raw_images, monkeypatch, shared_model_cache_dir, "--experimental-raw-support", "boat on a lake"
+  )
 
 
 @pytest.mark.usefixtures("assert_output_snapshot_raw_images")
 def test_can_read_arw_images(
   test_dir_with_raw_images: Path,
   monkeypatch: pytest.MonkeyPatch,
+  shared_model_cache_dir: str,
 ):
   # DSC08882.ARW should be at the top of the results
-  execute_query(test_dir_with_raw_images, monkeypatch, "--experimental-raw-support", "green ears of rye")
+  execute_query(
+    test_dir_with_raw_images, monkeypatch, shared_model_cache_dir, "--experimental-raw-support", "green ears of rye"
+  )
 
 
 @pytest.mark.usefixtures("assert_output_snapshot_raw_images")
 def test_can_read_cr2_images(
   test_dir_with_raw_images: Path,
   monkeypatch: pytest.MonkeyPatch,
+  shared_model_cache_dir: str,
 ):
   # RAW_CANON_400D_ARGB.CR2 should be at the top of the results
-  execute_query(test_dir_with_raw_images, monkeypatch, "--experimental-raw-support", "dragon in a cave")
+  execute_query(
+    test_dir_with_raw_images, monkeypatch, shared_model_cache_dir, "--experimental-raw-support", "dragon in a cave"
+  )
 
 
 @pytest.mark.usefixtures("assert_output_snapshot_unicode_filepaths")
-def test_unicode_filepaths(test_dir_with_unicode_filenames: Path, monkeypatch: pytest.MonkeyPatch):
-  execute_query(test_dir_with_unicode_filenames, monkeypatch, "鳥")
+def test_unicode_filepaths(
+  test_dir_with_unicode_filenames: Path, monkeypatch: pytest.MonkeyPatch, shared_model_cache_dir: str
+):
+  execute_query(test_dir_with_unicode_filenames, monkeypatch, shared_model_cache_dir, "鳥")

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import tempfile
 from typing import List, cast
 
@@ -97,3 +98,13 @@ def test_loads_full_model_when_text_processing_only_requested_and_checkpoint_doe
     assert model._model_var.transformer is not None  # type: ignore
     assert model._model_var.visual is not None  # type: ignore
     assert model._model_text_var is None  # type: ignore
+
+
+def test_uses_dedicated_model_cache_dir_when_configured(monkeypatch: pytest.MonkeyPatch):
+  with tempfile.TemporaryDirectory() as tmp_datadir, tempfile.TemporaryDirectory() as tmp_model_cache_dir:
+    monkeypatch.setenv("RCLIP_DATADIR", tmp_datadir)
+    monkeypatch.setenv("RCLIP_MODEL_CACHE_DIR", tmp_model_cache_dir)
+
+    model = Model()
+
+    assert model._text_model_path.parent == Path(tmp_model_cache_dir)  # type: ignore


### PR DESCRIPTION
## How does this PR impact the user?

Every e2e test redownloads the model, while it only needs to clear the rclip database, wasting dozens of minutes across all platform test runs.

## Description

- [x] introduce `RCLIP_MODEL_CACHE_DIR` and use it to ensure the e2e tests reuse a single model cache

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes