### PR TITLE
chore: run prerelease CI on macOS 26 (kept daily on macOS 14)

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.11', '3.12', '3.13']
-        os: [ubuntu-22.04, macos-14, windows-2022]
+        os: [ubuntu-22.04, macos-26, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## How does this PR impact the user?

More stable releases because we get more confidence that rclip works on the latest macOS when it's released.

## Description

Ditto.

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
