### PR TITLE
ci: ensure uv remains in path when running tests on a Windows build

### DIFF
--- a/.github/actions/test-system-rclip/action.yaml
+++ b/.github/actions/test-system-rclip/action.yaml
@@ -31,6 +31,6 @@ runs:
       # on Windows, we set the latest PATH to ensure that the action can find
       # system rclip
       # on other OSes, we pass -ieo pipefail to bash to ensure it reads the .bashrc
-      shell: ${{ (runner.os != 'Windows' || inputs.force-bash == 'true') && 'bash -ieo pipefail {0}' || 'powershell -NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -Command "$env:Path = [Environment]::GetEnvironmentVariable(''Path'', ''Machine'') + '';'' + [Environment]::GetEnvironmentVariable(''Path'', ''User''); & {0}"' }}
+      shell: ${{ (runner.os != 'Windows' || inputs.force-bash == 'true') && 'bash -ieo pipefail {0}' || 'powershell -NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -Command "$env:Path = [Environment]::GetEnvironmentVariable(''Path'', ''Machine'') + '';'' + [Environment]::GetEnvironmentVariable(''Path'', ''User'') + '';'' + $env:Path; & {0}"' }}
     - run: make test-system-rclip
-      shell: ${{ (runner.os != 'Windows' || inputs.force-bash == 'true') && 'bash -ieo pipefail {0}' || 'powershell -NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -Command "$env:Path = [Environment]::GetEnvironmentVariable(''Path'', ''Machine'') + '';'' + [Environment]::GetEnvironmentVariable(''Path'', ''User''); & {0}"' }}
+      shell: ${{ (runner.os != 'Windows' || inputs.force-bash == 'true') && 'bash -ieo pipefail {0}' || 'powershell -NoLogo -NonInteractive -ExecutionPolicy RemoteSigned -Command "$env:Path = [Environment]::GetEnvironmentVariable(''Path'', ''Machine'') + '';'' + [Environment]::GetEnvironmentVariable(''Path'', ''User'') + '';'' + $env:Path; & {0}"' }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # the `release` action uses `sed` expressions which are only compatible with the GNU sed
-ifeq ($(shell which gsed),)
+ifeq ($(shell command -v gsed 2>/dev/null),)
     SED := sed
 else
     SED := gsed

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # the `release` action uses `sed` expressions which are only compatible with the GNU sed
-ifeq ($(shell command -v gsed 2>/dev/null),)
+ifeq ($(shell which gsed),)
     SED := sed
 else
     SED := gsed


### PR DESCRIPTION
## How does this PR impact the user?

We will be able to build and release Windows packages.

## Description

Fix the paths on Windows to ensure uv remains there.

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
