### PR TITLE
ci: Windows MSI shouldn't bundle dev deps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -209,7 +209,7 @@ jobs:
           python-version: '3.11'
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install dependencies
-        run: uv sync --locked
+        run: uv sync --locked --no-dev
       - run: make build-windows
       - name: Install Advinst
         uses: caphyon/advinst-github-action@main

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-docker:
 
 # CI runs release-brew as part of the `release` action
 build-windows:
-	uv run --with pyinstaller==6.10.0 pyinstaller -y ./release-utils/windows/pyinstaller.spec
+	uv run --exact --no-dev --with pyinstaller==6.10.0 pyinstaller -y ./release-utils/windows/pyinstaller.spec
 
 # CI runs release-brew as part of the `release` action
 release-brew:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ rclip = "rclip.main:main"
 
 [dependency-groups]
 dev = [
-    "coremltools>=9.0,<10 ; sys_platform != 'windows'",
+    "coremltools>=9.0,<10 ; sys_platform != 'win32'",
     "open_clip_torch>=3.2.0,<4",
     "pytest>=7.2.1,<10.0",
     "ruff>=0.9.7,<0.10",

--- a/uv.lock
+++ b/uv.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "coremltools", marker = "sys_platform != 'windows'" },
+    { name = "coremltools", marker = "sys_platform != 'win32'" },
     { name = "jinja2" },
     { name = "open-clip-torch" },
     { name = "pytest" },
@@ -932,7 +932,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "coremltools", marker = "sys_platform != 'windows'", specifier = ">=9.0,<10" },
+    { name = "coremltools", marker = "sys_platform != 'win32'", specifier = ">=9.0,<10" },
     { name = "jinja2", specifier = ">=3.1.5,<4" },
     { name = "open-clip-torch", specifier = ">=3.2.0,<4" },
     { name = "pytest", specifier = ">=7.2.1,<10.0" },


### PR DESCRIPTION
## How does this PR impact the user?

Windows user will have a smaller download when using `rclip`.

## Description

- [x] don't install dev deps when building the Windows MSI
- [x] gate `coremltools` install using `!= 'win32'` instead of `!= 'windows'`

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
