### PR TITLE
chore: speedup AppImage cold start by uzing faster compression algorithm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,10 +173,15 @@ jobs:
           wget -O appimage-builder-x86_64.AppImage https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage
           chmod +x appimage-builder-x86_64.AppImage
           sudo mv appimage-builder-x86_64.AppImage /usr/local/bin/appimage-builder
+      - name: Install appimagetool
+        run: |
+          wget -O appimagetool-x86_64.AppImage https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage
+          chmod +x appimagetool-x86_64.AppImage
+          sudo mv appimagetool-x86_64.AppImage /usr/local/bin/appimagetool
       - name: Build AppImage
         env:
           APP_VERSION: ${{ needs.parse_tag.outputs.version }}
-        run: appimage-builder --skip-tests --recipe ./release-utils/appimage/appimage-builder.yml
+        run: bash ./release-utils/appimage/build_appimage.sh
       - uses: actions/upload-artifact@v7
         with:
           name: appimage

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ else
 endif
 
 build-appimage:
-	appimage-builder --recipe ./release-utils/appimage/appimage-builder.yml
+	APP_VERSION=$(shell python3 -c 'from pathlib import Path; import tomllib; print(tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"])') bash ./release-utils/appimage/build_appimage.sh
 
 lint-style:
 	uv run ruff check

--- a/release-utils/appimage/appimage-builder.yml
+++ b/release-utils/appimage/appimage-builder.yml
@@ -3,7 +3,7 @@ script:
   # Ensure that the mksquashfs tool is installed (workaround for the AppImageCrafters/build-appimage GHA)
   - which mksquashfs || apt-get install -y squashfs-tools
   # Remove any previous build
-  - rm -rf AppDir | true
+  - rm -rf AppDir appimage-build .bundle.yml rclip-*.AppImage rclip-*.AppImage.zsync | true
   # Make usr and icons dirs
   - mkdir -p AppDir/usr/src AppDir/usr/share/icons/hicolor/256x256/apps/
   # Copy the python application code and icon into the AppDir

--- a/release-utils/appimage/build_appimage.sh
+++ b/release-utils/appimage/build_appimage.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+app_version=${APP_VERSION:?APP_VERSION is required}
+recipe=./release-utils/appimage/appimage-builder.yml
+appdir=./AppDir
+artifact="rclip-${app_version}-x86_64.AppImage"
+update_information='gh-releases-zsync|AppImageCrafters|python-appimage-example|latest|python-appimage-*x86_64.AppImage.zsync'
+
+rm -rf "$appdir" appimage-build .bundle.yml "$artifact" "${artifact}.zsync"
+
+appimage-builder --skip-tests --skip-appimage --recipe "$recipe"
+ARCH=x86_64 appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 3 --mksquashfs-opt -b --mksquashfs-opt 128K --no-appstream --updateinformation "$update_information" "$appdir" "$artifact"


### PR DESCRIPTION
## How does this PR impact the user?

AppImage will start 2.75x faster.

## Description

- [x] replace `xz` compression with `zstd` (compression level 3)
- [x] bump AppImage to 1.9.1

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
