### PR TITLE
ci(windows): ensure pyinstaller discovers onnxruntime

### DIFF
--- a/release-utils/windows/pyinstaller.spec
+++ b/release-utils/windows/pyinstaller.spec
@@ -13,7 +13,9 @@ a = Analysis(
     datas=[
         *collect_data_files('onnxruntime'),
     ],
-    hiddenimports=[],
+    # rclip imports onnxruntime dynamically, so PyInstaller won't see it unless we
+    # declare it explicitly.
+    hiddenimports=['onnxruntime'],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],


### PR DESCRIPTION
## How does this PR impact the user?

We will be able to build MSI for Windows again.

## Description

Force pyinstaller to bundle onnxruntime when building the MSI despite it being imported dynamically.

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes