### PR TITLE
fix: preview images output to a background iTerm tab should be the right size

### DIFF
--- a/rclip/utils/preview.py
+++ b/rclip/utils/preview.py
@@ -1,6 +1,7 @@
 import base64
 from io import BytesIO
 import os
+import sys
 from PIL import Image
 
 from rclip.utils.helpers import read_image
@@ -20,6 +21,30 @@ def _get_end_sequence():
   return "\a"
 
 
+def _get_preview_dimensions(width_px: int, height_px: int) -> tuple[str, str]:
+  if sys.stdout.isatty() and os.name != "nt":
+    try:
+      import fcntl
+      import struct
+      import termios
+
+      rows, cols, terminal_width_px, terminal_height_px = struct.unpack(
+        "HHHH",
+        fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, struct.pack("HHHH", 0, 0, 0, 0)),
+      )
+      if rows > 0 and cols > 0 and terminal_width_px > 0 and terminal_height_px > 0:
+        cell_width_px = terminal_width_px / cols
+        cell_height_px = terminal_height_px / rows
+        return (
+          str(max(1, round(width_px / cell_width_px))),
+          str(max(1, round(height_px / cell_height_px))),
+        )
+    except OSError:
+      pass
+
+  return f"{width_px}px", f"{height_px}px"
+
+
 def preview(filepath: str, img_height_px: int):
   with read_image(filepath) as img:
     if img_height_px >= img.height:
@@ -31,8 +56,9 @@ def preview(filepath: str, img_height_px: int):
     img.convert("RGB").save(buffer, format="JPEG")
   img_bytes = buffer.getvalue()
   img_str = base64.b64encode(img_bytes).decode("utf-8")
+  width, height = _get_preview_dimensions(width_px, height_px)
   print(
     f"{_get_start_sequence()}1337;"
     f"File=inline=1;size={len(img_bytes)};preserveAspectRatio=1;"
-    f"width={width_px}px;height={height_px}px:{img_str}{_get_end_sequence()}",
+    f"width={width};height={height}:{img_str}{_get_end_sequence()}",
   )

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -13,12 +13,17 @@ def test_preview_uses_terminal_cell_dimensions_when_available(monkeypatch, capsy
   preview_module.preview("cat.jpg", 50)
 
   output = capsys.readouterr().out.rstrip("\n")
+  start_sequence = preview_module._get_start_sequence()
+  end_sequence = preview_module._get_end_sequence()
+
   assert ";width=10;height=5:" in output
+  assert output.startswith(f"{start_sequence}1337;File=inline=1;size=")
+  assert output.endswith(end_sequence)
 
   metadata, encoded_image = output.split(":", 1)
-  assert metadata.startswith("\033]1337;File=inline=1;size=")
+  assert metadata.startswith(f"{start_sequence}1337;File=inline=1;size=")
 
-  image = Image.open(BytesIO(base64.b64decode(encoded_image.removesuffix("\a"))))
+  image = Image.open(BytesIO(base64.b64decode(encoded_image.removesuffix(end_sequence))))
   assert image.size == (100, 50)
 
 

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -1,0 +1,28 @@
+import base64
+from io import BytesIO
+
+from PIL import Image
+
+from rclip.utils import preview as preview_module
+
+
+def test_preview_uses_terminal_cell_dimensions_when_available(monkeypatch, capsys):
+  monkeypatch.setattr(preview_module, "read_image", lambda _filepath: Image.new("RGB", (200, 100), "red"))
+  monkeypatch.setattr(preview_module, "_get_preview_dimensions", lambda _width, _height: ("10", "5"))
+
+  preview_module.preview("cat.jpg", 50)
+
+  output = capsys.readouterr().out.rstrip("\n")
+  assert ";width=10;height=5:" in output
+
+  metadata, encoded_image = output.split(":", 1)
+  assert metadata.startswith("\033]1337;File=inline=1;size=")
+
+  image = Image.open(BytesIO(base64.b64decode(encoded_image.removesuffix("\a"))))
+  assert image.size == (100, 50)
+
+
+def test_get_preview_dimensions_falls_back_to_pixels_when_tty_geometry_is_unavailable(monkeypatch):
+  monkeypatch.setattr(preview_module.sys.stdout, "isatty", lambda: False)
+
+  assert preview_module._get_preview_dimensions(120, 60) == ("120px", "60px")


### PR DESCRIPTION
## How does this PR impact the user?

If the user runs `rclip --preview` in iTerm, then switches to a different iTerm tab before it had the chance to output the results, the preview will have the correct dimensions instead of being oversized.

### Before the fix

<img width="1137" height="814" alt="Screenshot 2026-05-11 at 12 52 30" src="https://github.com/user-attachments/assets/720cd008-ea63-4829-93f0-78e419ae63df" />

## Description

- [x] update the size calculations to account for actual terminal dimensions/scale rather than on the image size alone

### After the fix

<img width="543" height="275" alt="Screenshot 2026-05-11 at 12 53 20" src="https://github.com/user-attachments/assets/2da302be-9b31-47f2-a529-5c7088c77a85" />

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [x] I have added screenshots or screen recordings to show the changes