### PR TITLE
perf: speed up pure text search by 13% by lazy loading libraw and libheif

### DIFF
--- a/rclip/main.py
+++ b/rclip/main.py
@@ -8,18 +8,13 @@ from typing import Iterable, List, NamedTuple, Optional, Tuple, TypedDict, cast
 import numpy as np
 from tqdm import tqdm
 import PIL
-from PIL import Image, ImageFile
-from pillow_heif import register_heif_opener
+from PIL import Image
 
 from rclip import db, fs, model
 from rclip.const import IMAGE_EXT, IMAGE_RAW_EXT
 from rclip.utils.preview import preview
 from rclip.utils.snap import check_snap_permissions, is_snap, get_snap_permission_error
 from rclip.utils import helpers
-
-
-setattr(ImageFile, "LOAD_TRUNCATED_IMAGES", True)
-register_heif_opener()
 
 
 class ImageMeta(TypedDict):

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -29,7 +29,7 @@ def _ensure_image_loading_configured() -> None:
   from PIL import ImageFile
   from pillow_heif import register_heif_opener
 
-  ImageFile.LOAD_TRUNCATED_IMAGES = True
+  setattr(ImageFile, "LOAD_TRUNCATED_IMAGES", True)
   register_heif_opener()
   _image_loading_configured = True
 

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -6,8 +6,6 @@ from typing import IO, cast
 from PIL import Image, UnidentifiedImageError
 import re
 import numpy as np
-import rawpy
-import requests
 import sys
 from importlib.metadata import version
 
@@ -18,6 +16,22 @@ MAX_DOWNLOAD_SIZE_BYTES = 50_000_000
 DOWNLOAD_TIMEOUT_SECONDS = 60
 WIN_ABSOLUTE_FILE_PATH_REGEX = re.compile(r"^[a-z]:\\", re.I)
 DEFAULT_TERMINAL_TEXT_WIDTH = 100
+
+_image_loading_configured = False
+
+
+def _ensure_image_loading_configured() -> None:
+  """Configures PIL for reading the images rclip works with. Imports pillow_heif (which loads the
+  native libheif) lazily so runs that never open an image don't pay for it."""
+  global _image_loading_configured
+  if _image_loading_configured:
+    return
+  from PIL import ImageFile
+  from pillow_heif import register_heif_opener
+
+  ImageFile.LOAD_TRUNCATED_IMAGES = True
+  register_heif_opener()
+  _image_loading_configured = True
 
 
 def __get_system_datadir() -> pathlib.Path:
@@ -196,6 +210,9 @@ def init_arg_parser() -> argparse.ArgumentParser:
 
 # See: https://meta.wikimedia.org/wiki/User-Agent_policy
 def download_image(url: str) -> Image.Image:
+  import requests
+
+  _ensure_image_loading_configured()
   headers = {"User-agent": "rclip - (https://github.com/yurijmikhalevich/rclip)"}
   check_size = requests.request("HEAD", url, headers=headers, timeout=60)
   if length := check_size.headers.get("Content-Length"):
@@ -212,12 +229,15 @@ def get_file_extension(path: str) -> str:
 
 
 def read_raw_image_file(path: str):
+  import rawpy
+
   with rawpy.imread(path) as raw:
     rgb = raw.postprocess()
   return Image.fromarray(np.array(rgb))
 
 
 def read_image(query: str) -> Image.Image:
+  _ensure_image_loading_configured()
   path = str.removeprefix(query, "file://")
   try:
     file_ext = get_file_extension(path)

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -507,13 +507,16 @@ def test_release_indexing_resources_shuts_down_preprocess_executor(monkeypatch: 
   monkeypatch.setitem(sys.modules, "coremltools.models", fake_coremltools_models)
   monkeypatch.setattr(model_download_module, "IS_MACOS", True)
   monkeypatch.delenv("RCLIP_USE_ONNX_ON_MACOS", raising=False)
+
   def fake_download_visual_index_model_package() -> str:
     return "/models/visual.mlpackage"
 
   def fake_ensure_compiled_coreml_model(path: str) -> str:
     return f"{Path(path).with_suffix('')}.mlmodelc"
 
-  monkeypatch.setattr(model_download_module, "download_visual_index_model_package", fake_download_visual_index_model_package)
+  monkeypatch.setattr(
+    model_download_module, "download_visual_index_model_package", fake_download_visual_index_model_package
+  )
   monkeypatch.setattr(model_download_module, "ensure_compiled_coreml_model", fake_ensure_compiled_coreml_model)
 
   model = Model()


### PR DESCRIPTION
## How does this PR impact the user?

When user searches images by text without reindexing, rclip will be a bit more faster.

## Description

- [x] lazy load libraw, libheif, and requests

### Before ~0.57s per text query

<img width="756" height="622" alt="image" src="https://github.com/user-attachments/assets/df3d2dc7-685c-49ad-b2ee-a3e5590dad90" />

### After ~0.5s - ~0.52s per text query

<img width="692" height="679" alt="image" src="https://github.com/user-attachments/assets/7b52239d-c986-40d3-b107-21259a302115" />

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [x] I have added screenshots or screen recordings to show the changes
