### PR TITLE
perf: speed up RAW image loading for up to 23x

### DIFF
--- a/rclip/main.py
+++ b/rclip/main.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import Iterable, List, NamedTuple, Optional, Tuple, TypedDict, cast
 
 import numpy as np
@@ -61,12 +62,34 @@ class RClip:
     excluded_dirs = "|".join(re.escape(dir) for dir in exclude_dirs or self.EXCLUDE_DIRS_DEFAULT)
     self._exclude_dir_regex = re.compile(f"^.+\\{os.path.sep}({excluded_dirs})(\\{os.path.sep}.+)?$")
 
+    self._image_loading_executor: Optional[ThreadPoolExecutor] = None
+    self._image_loading_workers = max(1, min(8, os.cpu_count() or 1))
+
+  def _get_image_loading_executor(self) -> ThreadPoolExecutor:
+    if self._image_loading_executor is None:
+      self._image_loading_executor = ThreadPoolExecutor(max_workers=self._image_loading_workers)
+    return self._image_loading_executor
+
+  def _shutdown_image_loading_executor(self) -> None:
+    if self._image_loading_executor is None:
+      return
+    self._image_loading_executor.shutdown(wait=True)
+    self._image_loading_executor = None
+
+  def close(self) -> None:
+    self._shutdown_image_loading_executor()
+
   def _index_files(self, filepaths: List[str], metas: List[ImageMeta]):
     images: List[Image.Image] = []
     filtered_paths: List[str] = []
-    for path in filepaths:
+
+    helpers._ensure_image_loading_configured()
+    executor = self._get_image_loading_executor()
+    futures = [executor.submit(helpers.read_image, path) for path in filepaths]
+
+    for path, future in zip(filepaths, futures):
       try:
-        image = helpers.read_image(path)
+        image = future.result()
         images.append(image)
         filtered_paths.append(path)
       except PIL.UnidentifiedImageError:
@@ -277,6 +300,7 @@ def main():
     result = rclip.search(args.query, current_directory, args.top, args.add, args.subtract)
     print_results(result, args)
   finally:
+    rclip.close()
     model_instance.close()
     db.close()
 

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -231,7 +231,7 @@ def read_raw_image_file(path: str):
   import rawpy
 
   with rawpy.imread(path) as raw:
-    rgb = raw.postprocess()
+    rgb = raw.postprocess(half_size=True)
   return Image.fromarray(np.array(rgb))
 
 

--- a/tests/e2e/output_snapshots/test_can_read_arw_images.txt
+++ b/tests/e2e/output_snapshots/test_can_read_arw_images.txt
@@ -1,6 +1,6 @@
 score	filepath
-0.271	"<test_images_dir>DSC08882.ARW"
-0.159	"<test_images_dir>RAW_LEICA_M8.DNG"
+0.270	"<test_images_dir>DSC08882.ARW"
+0.158	"<test_images_dir>RAW_LEICA_M8.DNG"
 0.129	"<test_images_dir>boats on a lake.png"
 0.089	"<test_images_dir>DSC03671.dng"
-0.063	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
+0.064	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"

--- a/tests/e2e/output_snapshots/test_can_read_cr2_images.txt
+++ b/tests/e2e/output_snapshots/test_can_read_cr2_images.txt
@@ -1,6 +1,6 @@
 score	filepath
-0.302	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
+0.300	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
 0.080	"<test_images_dir>RAW_LEICA_M8.DNG"
 0.055	"<test_images_dir>boats on a lake.png"
 0.032	"<test_images_dir>DSC08882.ARW"
-0.005	"<test_images_dir>DSC03671.dng"
+0.006	"<test_images_dir>DSC03671.dng"

--- a/tests/e2e/output_snapshots/test_can_read_dng_images.txt
+++ b/tests/e2e/output_snapshots/test_can_read_dng_images.txt
@@ -1,6 +1,6 @@
 score	filepath
 0.309	"<test_images_dir>DSC03671.dng"
-0.083	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
+0.084	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
 0.073	"<test_images_dir>boats on a lake.png"
-0.055	"<test_images_dir>DSC08882.ARW"
+0.057	"<test_images_dir>DSC08882.ARW"
 0.050	"<test_images_dir>RAW_LEICA_M8.DNG"

--- a/tests/e2e/output_snapshots/test_ignores_raw_if_there_is_a_png_named_the_same_way_in_the_same_dir.txt
+++ b/tests/e2e/output_snapshots/test_ignores_raw_if_there_is_a_png_named_the_same_way_in_the_same_dir.txt
@@ -1,6 +1,6 @@
 score	filepath
 0.301	"<test_images_dir>boats on a lake.png"
-0.144	"<test_images_dir>RAW_LEICA_M8.DNG"
-0.119	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
+0.145	"<test_images_dir>RAW_LEICA_M8.DNG"
+0.120	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
 0.083	"<test_images_dir>DSC08882.ARW"
-0.042	"<test_images_dir>DSC03671.dng"
+0.043	"<test_images_dir>DSC03671.dng"


### PR DESCRIPTION
## How does this PR impact the user?

### Before

<img width="868" height="299" alt="Screenshot 2026-06-11 at 11 09 48" src="https://github.com/user-attachments/assets/ddf41f61-ce10-4a6f-a173-570805988da1" />

### After

<img width="861" height="312" alt="Screenshot 2026-06-11 at 11 10 50" src="https://github.com/user-attachments/assets/26328a22-9f06-4b7e-bab7-49f989e1e667" />

## Description

- [x] parallelize image loading (affects RAW since Pillow was lazy loaded anyway)
- [x] preprocess RAW at half size for speed (we are downsizing the images for indexing anyway, so this doesn't impact the results)

## Limitations

The vectors for RAW images did change very slightly, but the change is very minor and will not affect users with the pre-indexed RAW images.

## Checklist

- [x] my PR is focused and contains one holistic change
- [x] I have added screenshots or screen recordings to show the changes
