### PR TITLE
fix: metadata should be attributed to the correct images even if one of them failed to load

### DIFF
--- a/rclip/main.py
+++ b/rclip/main.py
@@ -82,16 +82,18 @@ class RClip:
   def _index_files(self, filepaths: List[str], metas: List[ImageMeta]):
     images: List[Image.Image] = []
     filtered_paths: List[str] = []
+    filtered_metas: List[ImageMeta] = []
 
     helpers._ensure_image_loading_configured()
     executor = self._get_image_loading_executor()
     futures = [executor.submit(helpers.read_image, path) for path in filepaths]
 
-    for path, future in zip(filepaths, futures):
+    for path, meta, future in zip(filepaths, metas, futures):
       try:
         image = future.result()
         images.append(image)
         filtered_paths.append(path)
+        filtered_metas.append(meta)
       except PIL.UnidentifiedImageError:
         pass
       except Exception as ex:
@@ -102,7 +104,7 @@ class RClip:
     except Exception as ex:
       print("error computing features:", ex, file=sys.stderr)
       return
-    for path, meta, vector in cast(Iterable[PathMetaVector], zip(filtered_paths, metas, features)):
+    for path, meta, vector in cast(Iterable[PathMetaVector], zip(filtered_paths, filtered_metas, features)):
       self._db.upsert_image(
         db.NewImage(filepath=path, modified_at=meta["modified_at"], size=meta["size"], vector=vector.tobytes()),
         commit=False,

--- a/tests/unit/test_index_files.py
+++ b/tests/unit/test_index_files.py
@@ -9,9 +9,6 @@ from rclip.utils import helpers
 
 
 def test_index_files_keeps_meta_aligned_when_an_image_fails_to_load(monkeypatch):
-  # configuring PIL is irrelevant here and would import libheif; skip it
-  monkeypatch.setattr(helpers, "_ensure_image_loading_configured", lambda: None)
-
   # the middle image in the batch fails to load, shrinking the surviving paths/features
   def fake_read_image(path: str) -> Image.Image:
     if path == "b.jpg":

--- a/tests/unit/test_index_files.py
+++ b/tests/unit/test_index_files.py
@@ -1,0 +1,46 @@
+from unittest.mock import Mock
+
+import numpy as np
+import PIL
+from PIL import Image
+
+from rclip.main import ImageMeta, RClip
+from rclip.utils import helpers
+
+
+def test_index_files_keeps_meta_aligned_when_an_image_fails_to_load(monkeypatch):
+  # configuring PIL is irrelevant here and would import libheif; skip it
+  monkeypatch.setattr(helpers, "_ensure_image_loading_configured", lambda: None)
+
+  # the middle image in the batch fails to load, shrinking the surviving paths/features
+  def fake_read_image(path: str) -> Image.Image:
+    if path == "b.jpg":
+      raise PIL.UnidentifiedImageError()
+    return Image.new("RGB", (1, 1))
+
+  monkeypatch.setattr(helpers, "read_image", fake_read_image)
+
+  meta_a = ImageMeta(modified_at=1.0, size=100)
+  meta_b = ImageMeta(modified_at=2.0, size=200)
+  meta_c = ImageMeta(modified_at=3.0, size=300)
+
+  model = Mock()
+  # one feature vector per surviving image (a and c)
+  model.compute_image_features.return_value = [np.zeros(4, dtype=np.float32), np.ones(4, dtype=np.float32)]
+  database = Mock()
+
+  rclip = RClip(model, database, indexing_batch_size=8, exclude_dirs=None)
+  try:
+    rclip._index_files(["a.jpg", "b.jpg", "c.jpg"], [meta_a, meta_b, meta_c])
+  finally:
+    rclip.close()
+
+  upserted = {
+    (call.args[0]["filepath"], call.args[0]["modified_at"], call.args[0]["size"])
+    for call in database.upsert_image.call_args_list
+  }
+  # the surviving images must keep their own metas; before the fix c.jpg got meta_b
+  assert upserted == {
+    ("a.jpg", meta_a["modified_at"], meta_a["size"]),
+    ("c.jpg", meta_c["modified_at"], meta_c["size"]),
+  }


### PR DESCRIPTION
## How does this PR impact the user?

Tester will be less likely to reindex a previously correctly indexed image if the directory contains any broken images.

## Description

- [x] fix the bug
- [x] add a unit test

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
