### PR TITLE
perf(indexing): preload 3 batches + preprocess fully when loading

### DIFF
--- a/rclip/main.py
+++ b/rclip/main.py
@@ -8,12 +8,13 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Deque, Iterable, Iterator, List, NamedTuple, Optional, Tuple, TypedDict, cast
 
 import numpy as np
+import numpy.typing as npt
 from tqdm import tqdm
 import PIL
-from PIL import Image
 
 from rclip import db, fs, model
 from rclip.const import IMAGE_EXT, IMAGE_RAW_EXT
+from rclip.utils.preprocess import preprocess
 from rclip.utils.preview import preview
 from rclip.utils.snap import check_snap_permissions, is_snap, get_snap_permission_error
 from rclip.utils import helpers
@@ -36,9 +37,21 @@ def is_image_meta_equal(image: db.Image, meta: ImageMeta) -> bool:
   return meta["modified_at"] == image["modified_at"] and meta["size"] == image["size"]
 
 
+def _read_and_preprocess(path: str) -> npt.NDArray[np.float32]:
+  """Reads an image and runs the CLIP preprocessing on it. Runs on the loader threads so that the
+  decoding and resizing happen in parallel and only the model forward pass is left for the consumer."""
+  return preprocess(helpers.read_image(path))
+
+
 class RClip:
   EXCLUDE_DIRS_DEFAULT = ["@eaDir", "node_modules", ".git"]
   DB_IMAGES_BEFORE_COMMIT = 50_000
+  # how many indexing batches to keep loading ahead of the model; preprocessed images are small
+  # (a few hundred KB each), so a few batches of look-ahead cost little memory.
+  LOOKAHEAD_BATCHES = 3
+  # the loader threads now do the whole per-image CPU cost (decode + preprocess), so size the pool
+  # to the number of cores rather than capping it low.
+  MAX_IMAGE_LOADING_WORKERS = 16
 
   class SearchResult(NamedTuple):
     filepath: str
@@ -64,7 +77,7 @@ class RClip:
     self._exclude_dir_regex = re.compile(f"^.+\\{os.path.sep}({excluded_dirs})(\\{os.path.sep}.+)?$")
 
     self._image_loading_executor: Optional[ThreadPoolExecutor] = None
-    self._image_loading_workers = max(1, min(8, os.cpu_count() or 1))
+    self._image_loading_workers = max(1, min(self.MAX_IMAGE_LOADING_WORKERS, os.cpu_count() or 1))
 
   def _get_image_loading_executor(self) -> ThreadPoolExecutor:
     if self._image_loading_executor is None:
@@ -82,26 +95,26 @@ class RClip:
 
   def _load_images(
     self, items: Iterable[Tuple[str, ImageMeta]]
-  ) -> Iterator[Tuple[str, ImageMeta, Image.Image]]:
-    """Loads images in parallel, keeping a bounded look-ahead so decoding overlaps with whatever the
-    consumer does between iterations (model inference). Yields successfully loaded (path, meta, image)
-    tuples in input order; images that fail to load are skipped.
+  ) -> Iterator[Tuple[str, ImageMeta, npt.NDArray[np.float32]]]:
+    """Reads and preprocesses images in parallel, keeping a bounded look-ahead so this work overlaps
+    with whatever the consumer does between iterations (model inference). Yields successfully loaded
+    (path, meta, preprocessed_image) tuples in input order; images that fail to load are skipped.
 
-    Only image loading runs on worker threads here; the model and the database are driven by the
-    consumer on the calling thread, so neither is ever touched concurrently."""
+    Preprocessed images are small and fixed-size, so the look-ahead buffer stays cheap even a few
+    batches deep. Only image loading runs on worker threads here; the model and the database are
+    driven by the consumer on the calling thread, so neither is ever touched concurrently."""
     helpers._ensure_image_loading_configured()
     executor = self._get_image_loading_executor()
-    # keep at least a full next batch in flight so it can decode while the model processes the
-    # current one, while holding only ~one extra batch of decoded images in memory.
-    max_in_flight = self._indexing_batch_size + self._image_loading_workers
+    # keep a few full batches in flight so they preprocess while the model processes the current one.
+    max_in_flight = max(self.LOOKAHEAD_BATCHES * self._indexing_batch_size, self._image_loading_workers)
     items_iter = iter(items)
-    in_flight: Deque[Tuple[str, ImageMeta, Future[Image.Image]]] = deque()
+    in_flight: Deque[Tuple[str, ImageMeta, Future[npt.NDArray[np.float32]]]] = deque()
 
     def submit_next() -> None:
       item = next(items_iter, None)
       if item is not None:
         path, meta = item
-        in_flight.append((path, meta, executor.submit(helpers.read_image, path)))
+        in_flight.append((path, meta, executor.submit(_read_and_preprocess, path)))
 
     for _ in range(max_in_flight):
       submit_next()
@@ -119,7 +132,7 @@ class RClip:
   def _index_images(self, items: Iterable[Tuple[str, ImageMeta]]) -> None:
     paths: List[str] = []
     metas: List[ImageMeta] = []
-    images: List[Image.Image] = []
+    images: List[npt.NDArray[np.float32]] = []
 
     def flush() -> None:
       if images:
@@ -136,9 +149,11 @@ class RClip:
         flush()
     flush()
 
-  def _store_image_features(self, paths: List[str], metas: List[ImageMeta], images: List[Image.Image]) -> None:
+  def _store_image_features(
+    self, paths: List[str], metas: List[ImageMeta], images: List[npt.NDArray[np.float32]]
+  ) -> None:
     try:
-      features = self._model.compute_image_features(images, for_indexing=True)
+      features = self._model.compute_image_features_from_preprocessed(images, for_indexing=True)
     except Exception as ex:
       print("error computing features:", ex, file=sys.stderr)
       return

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -38,19 +38,19 @@ def is_image_meta_equal(image: db.Image, meta: ImageMeta) -> bool:
 
 
 def _read_and_preprocess(path: str) -> npt.NDArray[np.float32]:
-  """Reads an image and runs the CLIP preprocessing on it. Runs on the loader threads so that the
-  decoding and resizing happen in parallel and only the model forward pass is left for the consumer."""
+  """Reads an image and runs the CLIP preprocessing on it. Runs on the loader
+  threads so that the decoding and resizing happen in parallel and only the
+  model forward pass is left for the consumer."""
   return preprocess(helpers.read_image(path))
 
 
 class RClip:
   EXCLUDE_DIRS_DEFAULT = ["@eaDir", "node_modules", ".git"]
   DB_IMAGES_BEFORE_COMMIT = 50_000
-  # how many indexing batches to keep loading ahead of the model; preprocessed images are small
-  # (a few hundred KB each), so a few batches of look-ahead cost little memory.
+  # how many indexing batches to keep loading ahead of the model; preprocessed
+  # images are small (a few hundred KB each), so a few batches of look-ahead
+  # cost little memory.
   LOOKAHEAD_BATCHES = 3
-  # the loader threads now do the whole per-image CPU cost (decode + preprocess), so size the pool
-  # to the number of cores rather than capping it low.
   MAX_IMAGE_LOADING_WORKERS = 16
 
   class SearchResult(NamedTuple):
@@ -96,16 +96,10 @@ class RClip:
   def _load_images(
     self, items: Iterable[Tuple[str, ImageMeta]]
   ) -> Iterator[Tuple[str, ImageMeta, npt.NDArray[np.float32]]]:
-    """Reads and preprocesses images in parallel, keeping a bounded look-ahead so this work overlaps
-    with whatever the consumer does between iterations (model inference). Yields successfully loaded
-    (path, meta, preprocessed_image) tuples in input order; images that fail to load are skipped.
-
-    Preprocessed images are small and fixed-size, so the look-ahead buffer stays cheap even a few
-    batches deep. Only image loading runs on worker threads here; the model and the database are
-    driven by the consumer on the calling thread, so neither is ever touched concurrently."""
     helpers._ensure_image_loading_configured()
     executor = self._get_image_loading_executor()
-    # keep a few full batches in flight so they preprocess while the model processes the current one.
+    # keep a few full batches in flight so they preprocess while the model
+    # processes the current one.
     max_in_flight = max(self.LOOKAHEAD_BATCHES * self._indexing_batch_size, self._image_loading_workers)
     items_iter = iter(items)
     in_flight: Deque[Tuple[str, ImageMeta, Future[npt.NDArray[np.float32]]]] = deque()
@@ -153,7 +147,7 @@ class RClip:
     self, paths: List[str], metas: List[ImageMeta], images: List[npt.NDArray[np.float32]]
   ) -> None:
     try:
-      features = self._model.compute_image_features_from_preprocessed(images, for_indexing=True)
+      features = self._model.compute_preprocessed_image_features(images, for_indexing=True)
     except Exception as ex:
       print("error computing features:", ex, file=sys.stderr)
       return

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -96,13 +96,6 @@ class Model:
   def _run_textual(self, tokens: npt.NDArray[np.int64]) -> npt.NDArray[np.float32]:
     return self._run_session(self._session_text, tokens)
 
-  def _encode_preprocessed_batch(
-    self, batch: npt.NDArray[np.float32], *, for_indexing: bool
-  ) -> npt.NDArray[np.float32]:
-    image_features = self._run_visual(batch, for_indexing=for_indexing)
-    image_features = image_features / np.linalg.norm(image_features, axis=-1, keepdims=True)
-    return image_features
-
   def compute_image_features(self, images: List[Image.Image], *, for_indexing: bool = False) -> npt.NDArray[np.float32]:
     return self.compute_preprocessed_image_features([preprocess(image) for image in images], for_indexing=for_indexing)
 
@@ -110,7 +103,9 @@ class Model:
     self, preprocessed_images: List[npt.NDArray[np.float32]], *, for_indexing: bool = False
   ) -> npt.NDArray[np.float32]:
     batch = np.stack(preprocessed_images)
-    return self._encode_preprocessed_batch(batch, for_indexing=for_indexing)
+    image_features = self._run_visual(batch, for_indexing=for_indexing)
+    image_features = image_features / np.linalg.norm(image_features, axis=-1, keepdims=True)
+    return image_features
 
   def compute_text_features(self, text: List[str]) -> npt.NDArray[np.float32]:
     tokens = self._tokenizer(text)

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -1,6 +1,4 @@
-from concurrent.futures import ThreadPoolExecutor
 import logging
-import os
 import re
 from typing import Any, List, Optional, Tuple
 
@@ -28,20 +26,11 @@ class Model:
     self._session_visual_var: Optional[Any] = None
     self._session_visual_index_var: Optional[Any] = None
     self._tokenizer_var: Optional[SimpleTokenizer] = None
-    self._preprocess_executor_var: Optional[ThreadPoolExecutor] = None
-    self._preprocess_workers = max(1, min(8, os.cpu_count() or 1))
 
   def ensure_downloaded(self) -> None:
     model_download.ensure_downloaded()
 
-  def _shutdown_preprocess_executor(self) -> None:
-    if self._preprocess_executor_var is None:
-      return
-    self._preprocess_executor_var.shutdown(wait=True)
-    self._preprocess_executor_var = None
-
   def release_indexing_resources(self) -> None:
-    self._shutdown_preprocess_executor()
     self._session_visual_index_var = None
 
   def close(self) -> None:
@@ -107,16 +96,24 @@ class Model:
   def _run_textual(self, tokens: npt.NDArray[np.int64]) -> npt.NDArray[np.float32]:
     return self._run_session(self._session_text, tokens)
 
-  def compute_image_features(self, images: List[Image.Image], *, for_indexing: bool = False) -> npt.NDArray[np.float32]:
-    if len(images) < 2 or self._preprocess_workers == 1:
-      batch = np.stack([preprocess(img) for img in images])
-    else:
-      if self._preprocess_executor_var is None:
-        self._preprocess_executor_var = ThreadPoolExecutor(max_workers=self._preprocess_workers)
-      batch = np.stack(list(self._preprocess_executor_var.map(preprocess, images)))
+  def _encode_preprocessed_batch(
+    self, batch: npt.NDArray[np.float32], *, for_indexing: bool
+  ) -> npt.NDArray[np.float32]:
     image_features = self._run_visual(batch, for_indexing=for_indexing)
     image_features = image_features / np.linalg.norm(image_features, axis=-1, keepdims=True)
     return image_features
+
+  def compute_image_features(self, images: List[Image.Image], *, for_indexing: bool = False) -> npt.NDArray[np.float32]:
+    batch = np.stack([preprocess(image) for image in images])
+    return self._encode_preprocessed_batch(batch, for_indexing=for_indexing)
+
+  def compute_image_features_from_preprocessed(
+    self, preprocessed_images: List[npt.NDArray[np.float32]], *, for_indexing: bool = False
+  ) -> npt.NDArray[np.float32]:
+    """Like compute_image_features, but takes images already run through preprocess() (e.g. on the
+    indexing loader threads), so only the model forward pass happens here."""
+    batch = np.stack(preprocessed_images)
+    return self._encode_preprocessed_batch(batch, for_indexing=for_indexing)
 
   def compute_text_features(self, text: List[str]) -> npt.NDArray[np.float32]:
     tokens = self._tokenizer(text)

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -104,14 +104,11 @@ class Model:
     return image_features
 
   def compute_image_features(self, images: List[Image.Image], *, for_indexing: bool = False) -> npt.NDArray[np.float32]:
-    batch = np.stack([preprocess(image) for image in images])
-    return self._encode_preprocessed_batch(batch, for_indexing=for_indexing)
+    return self.compute_preprocessed_image_features([preprocess(image) for image in images], for_indexing=for_indexing)
 
-  def compute_image_features_from_preprocessed(
+  def compute_preprocessed_image_features(
     self, preprocessed_images: List[npt.NDArray[np.float32]], *, for_indexing: bool = False
   ) -> npt.NDArray[np.float32]:
-    """Like compute_image_features, but takes images already run through preprocess() (e.g. on the
-    indexing loader threads), so only the model forward pass happens here."""
     batch = np.stack(preprocessed_images)
     return self._encode_preprocessed_batch(batch, for_indexing=for_indexing)
 

--- a/tests/unit/test_index_images.py
+++ b/tests/unit/test_index_images.py
@@ -49,7 +49,7 @@ def test_index_images_keeps_meta_aligned_when_an_image_fails_to_load(monkeypatch
 
   model = Mock()
   # one feature vector per surviving image (a and c)
-  model.compute_image_features_from_preprocessed.return_value = [
+  model.compute_preprocessed_image_features.return_value = [
     np.zeros(4, dtype=np.float32),
     np.ones(4, dtype=np.float32),
   ]

--- a/tests/unit/test_index_images.py
+++ b/tests/unit/test_index_images.py
@@ -34,7 +34,8 @@ def test_load_images_preserves_order_and_skips_failures(monkeypatch):
 
   # b.jpg failed to load and is dropped; the survivors keep their order and their own metas/images
   assert [(path, meta) for path, meta, _image in loaded] == [("a.jpg", meta_a), ("c.jpg", meta_c)]
-  assert all(isinstance(image, Image.Image) for _path, _meta, image in loaded)
+  # the loader threads preprocess the images, so it yields ready-to-encode CLIP tensors
+  assert all(isinstance(image, np.ndarray) and image.shape == (3, 256, 256) for _path, _meta, image in loaded)
 
 
 def test_index_images_keeps_meta_aligned_when_an_image_fails_to_load(monkeypatch):
@@ -48,7 +49,10 @@ def test_index_images_keeps_meta_aligned_when_an_image_fails_to_load(monkeypatch
 
   model = Mock()
   # one feature vector per surviving image (a and c)
-  model.compute_image_features.return_value = [np.zeros(4, dtype=np.float32), np.ones(4, dtype=np.float32)]
+  model.compute_image_features_from_preprocessed.return_value = [
+    np.zeros(4, dtype=np.float32),
+    np.ones(4, dtype=np.float32),
+  ]
   database = Mock()
 
   rclip = _make_rclip(model, database)

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -50,22 +50,6 @@ class FakeInferenceSession:
     return [types.SimpleNamespace(type="tensor(float)")]
 
 
-class FakeExecutor:
-  def __init__(self, max_workers: int):
-    self.max_workers = max_workers
-    self.shutdown_calls: list[bool] = []
-    self.is_shutdown = False
-
-  def map(self, func: Callable[[Image.Image], FeatureBatch], images: list[Image.Image]):
-    if self.is_shutdown:
-      raise RuntimeError("executor was already shut down")
-    return [func(image) for image in images]
-
-  def shutdown(self, wait: bool = True) -> None:
-    self.shutdown_calls.append(wait)
-    self.is_shutdown = True
-
-
 def test_download_coreml_model_materializes_real_package(monkeypatch: pytest.MonkeyPatch):
   def fake_get_app_datadir() -> Path:
     return Path("/tmp/rclip-datadir")
@@ -473,15 +457,7 @@ def test_compute_image_features_uses_separate_visual_session_for_indexing_on_mac
   assert created_sessions == [(str(Path("/models/visual.mlmodelc")), "all")]
 
 
-def test_release_indexing_resources_shuts_down_preprocess_executor(monkeypatch: pytest.MonkeyPatch):
-  fake_executors: list[FakeExecutor] = []
-
-  def fake_executor_factory(*, max_workers: int):
-    executor = FakeExecutor(max_workers)
-    fake_executors.append(executor)
-    return executor
-
-  monkeypatch.setattr(model_module, "ThreadPoolExecutor", fake_executor_factory)
+def test_release_indexing_resources_releases_visual_index_session(monkeypatch: pytest.MonkeyPatch):
   monkeypatch.setattr(model_module, "preprocess", _fake_preprocess)
 
   created_sessions: list[tuple[str, object]] = []
@@ -524,16 +500,13 @@ def test_release_indexing_resources_shuts_down_preprocess_executor(monkeypatch: 
 
   model.compute_image_features(images, for_indexing=True)
 
-  assert len(fake_executors) == 1
   assert created_sessions == [(str(Path("/models/visual.mlmodelc")), "all")]
 
+  # releasing indexing resources drops the visual index session so it is recreated on next use
   model.release_indexing_resources()
-
-  assert fake_executors[0].shutdown_calls == [True]
 
   model.compute_image_features(images, for_indexing=True)
 
-  assert len(fake_executors) == 2
   assert created_sessions == [
     (str(Path("/models/visual.mlmodelc")), "all"),
     (str(Path("/models/visual.mlmodelc")), "all"),


### PR DESCRIPTION
## How does this PR impact the user?

Indexing will be slightly faster.

## Description

- [x] make image loading also preprocess them
- [x] preload 3 batches
- [x] remove the preprocessing multithreading logic from `model.py`

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
