### PR TITLE
perf(indexing): read RAW previews when available (more than 3x speedup)

### DIFF
--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -1,4 +1,5 @@
 import argparse
+import io
 import os
 import pathlib
 import textwrap
@@ -10,6 +11,7 @@ import sys
 from importlib.metadata import version
 
 from rclip.const import IMAGE_RAW_EXT, IS_LINUX, IS_MACOS, IS_WINDOWS
+from rclip.utils import preprocess
 
 
 MAX_DOWNLOAD_SIZE_BYTES = 50_000_000
@@ -231,6 +233,17 @@ def read_raw_image_file(path: str):
   import rawpy
 
   with rawpy.imread(path) as raw:
+    # The embedded JPEG preview is usually large enough for the 256px model
+    # input and far cheaper to decode than demosaicing the whole sensor.
+    # Fall back to postprocess otherwise.
+    try:
+      thumb = raw.extract_thumb()
+      if thumb.format == rawpy.ThumbFormat.JPEG:
+        image = Image.open(io.BytesIO(thumb.data))
+        if min(image.size) >= preprocess.IMAGE_SIZE:
+          return image
+    except rawpy.LibRawNoThumbnailError:
+      pass
     rgb = raw.postprocess(half_size=True)
   return Image.fromarray(np.array(rgb))
 

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -238,11 +238,13 @@ def read_raw_image_file(path: str):
     # Fall back to postprocess otherwise.
     try:
       thumb = raw.extract_thumb()
-      if thumb.format == rawpy.ThumbFormat.JPEG:
+      # rawpy re-exports these from its compiled extension via
+      # globals().update, so ty can't see them.
+      if thumb.format == rawpy.ThumbFormat.JPEG:  # ty: ignore[unresolved-attribute]
         image = Image.open(io.BytesIO(thumb.data))
         if min(image.size) >= preprocess.IMAGE_SIZE:
           return image
-    except rawpy.LibRawNoThumbnailError:
+    except rawpy.LibRawNoThumbnailError:  # ty: ignore[unresolved-attribute]
       pass
     rgb = raw.postprocess(half_size=True)
   return Image.fromarray(np.array(rgb))

--- a/tests/e2e/output_snapshots/test_can_read_arw_images.txt
+++ b/tests/e2e/output_snapshots/test_can_read_arw_images.txt
@@ -1,6 +1,6 @@
 score	filepath
-0.270	"<test_images_dir>DSC08882.ARW"
+0.275	"<test_images_dir>DSC08882.ARW"
 0.158	"<test_images_dir>RAW_LEICA_M8.DNG"
 0.129	"<test_images_dir>boats on a lake.png"
-0.089	"<test_images_dir>DSC03671.dng"
-0.064	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
+0.081	"<test_images_dir>DSC03671.dng"
+0.067	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"

--- a/tests/e2e/output_snapshots/test_can_read_cr2_images.txt
+++ b/tests/e2e/output_snapshots/test_can_read_cr2_images.txt
@@ -1,6 +1,6 @@
 score	filepath
-0.300	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
+0.296	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
 0.080	"<test_images_dir>RAW_LEICA_M8.DNG"
 0.055	"<test_images_dir>boats on a lake.png"
-0.032	"<test_images_dir>DSC08882.ARW"
-0.006	"<test_images_dir>DSC03671.dng"
+0.026	"<test_images_dir>DSC08882.ARW"
+0.004	"<test_images_dir>DSC03671.dng"

--- a/tests/e2e/output_snapshots/test_can_read_dng_images.txt
+++ b/tests/e2e/output_snapshots/test_can_read_dng_images.txt
@@ -1,6 +1,6 @@
 score	filepath
-0.309	"<test_images_dir>DSC03671.dng"
-0.084	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
+0.307	"<test_images_dir>DSC03671.dng"
+0.096	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
 0.073	"<test_images_dir>boats on a lake.png"
-0.057	"<test_images_dir>DSC08882.ARW"
+0.055	"<test_images_dir>DSC08882.ARW"
 0.050	"<test_images_dir>RAW_LEICA_M8.DNG"

--- a/tests/e2e/output_snapshots/test_ignores_raw_if_there_is_a_png_named_the_same_way_in_the_same_dir.txt
+++ b/tests/e2e/output_snapshots/test_ignores_raw_if_there_is_a_png_named_the_same_way_in_the_same_dir.txt
@@ -1,6 +1,6 @@
 score	filepath
 0.301	"<test_images_dir>boats on a lake.png"
 0.145	"<test_images_dir>RAW_LEICA_M8.DNG"
-0.120	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
-0.083	"<test_images_dir>DSC08882.ARW"
-0.043	"<test_images_dir>DSC03671.dng"
+0.110	"<test_images_dir>RAW_CANON_400D_ARGB.CR2"
+0.065	"<test_images_dir>DSC08882.ARW"
+0.041	"<test_images_dir>DSC03671.dng"


### PR DESCRIPTION
## How does this PR impact the user?

Grab RAW image previews for indexing instead of preprocessing them.

### Before

<img width="1730" height="600" alt="image" src="https://github.com/user-attachments/assets/c7ce8f5e-98e9-4a5b-a2fb-12b456ae6c69" />

### After

<img width="863" height="304" alt="image" src="https://github.com/user-attachments/assets/9c64123d-4944-4cb8-93ac-15691ca92d61" />

## Description

Ditto.

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes