### PR TITLE
feat: let the user adjust max image size + fix potential OOM on low-RAM machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Run `rclip --help` (or `rclip -h`) to see this list in your terminal. The positi
 | `--indexing-batch-size`, `-b` `N` | The size of the image batch used when updating the search index. Larger values may slightly improve indexing speed on some hardware but increase RAM usage. Default: `8`. |
 | `--exclude-dir` `DIR` | Directory to exclude from search. Can be used multiple times. Specifying this overrides the default of `@eaDir`, `node_modules`, and `.git`. |
 | `--experimental-raw-support` | Enable support for RAW images (`arw`, `cr2`, and `dng` are supported). |
+| `--max-image-megapixels` `MP` | Maximum size, in megapixels, an image may have to be indexed. Larger images are skipped to avoid running out of memory on huge or maliciously crafted images. Pass `none` to disable the limit. Default: chosen automatically based on the available memory. |
 | `--version`, `-v` | Print the **rclip** version and exit. |
 | `--help`, `-h` | Show the help message and exit. |
 

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -11,6 +11,7 @@ import numpy as np
 import numpy.typing as npt
 from tqdm import tqdm
 import PIL
+import PIL.Image
 
 from rclip import db, fs, model
 from rclip.const import IMAGE_EXT, IMAGE_RAW_EXT
@@ -35,6 +36,15 @@ def get_image_meta(entry: os.DirEntry[str]) -> ImageMeta:
 
 def is_image_meta_equal(image: db.Image, meta: ImageMeta) -> bool:
   return meta["modified_at"] == image["modified_at"] and meta["size"] == image["size"]
+
+
+def _too_large_message(path: str, pixels: int, limit: int) -> str:
+  size = f" ({pixels / 1_000_000:.0f} MP)" if pixels else ""
+  return (
+    f"skipping {path}: it is too large to process{size};"
+    f" the limit is {limit / 1_000_000:.0f} MP."
+    ' Raise or disable it with "--max-image-megapixels" if you want to index this image'
+  )
 
 
 def _read_and_preprocess(path: str) -> npt.NDArray[np.float32]:
@@ -64,6 +74,7 @@ class RClip:
     indexing_batch_size: int,
     exclude_dirs: Optional[List[str]],
     enable_raw_support: bool = False,
+    max_image_pixels: helpers.MaxImagePixels = helpers.AUTO_MAX_IMAGE_PIXELS,
   ):
     self._model = model_instance
     self._db = database
@@ -78,6 +89,7 @@ class RClip:
 
     self._image_loading_executor: Optional[ThreadPoolExecutor] = None
     self._image_loading_workers = max(1, min(self.MAX_IMAGE_LOADING_WORKERS, os.cpu_count() or 1))
+    helpers.configure_max_image_pixels(max_image_pixels, self._image_loading_workers)
 
   def _get_image_loading_executor(self) -> ThreadPoolExecutor:
     if self._image_loading_executor is None:
@@ -118,10 +130,19 @@ class RClip:
       submit_next()  # refill so the window stays full while the consumer is busy
       try:
         yield path, meta, future.result()
+      except helpers.ImageTooLargeError as ex:
+        print(_too_large_message(path, ex.pixels, ex.limit), file=sys.stderr)
+      except (PIL.Image.DecompressionBombError, PIL.Image.DecompressionBombWarning) as ex:
+        # backstop for formats whose true size only surfaces while decoding in the worker
+        print(
+          _too_large_message(path, helpers._parse_bomb_pixels(ex), helpers.get_max_image_pixels() or 0), file=sys.stderr
+        )
+      except MemoryError:
+        print(f"skipping {path}: ran out of memory while processing it", file=sys.stderr)
       except PIL.UnidentifiedImageError:
-        pass
+        print(f"skipping {path}: it is not a readable image", file=sys.stderr)
       except Exception as ex:
-        print(f"error loading image {path}:", ex, file=sys.stderr)
+        print(f"skipping {path}: {ex}", file=sys.stderr)
 
   def _index_images(self, items: Iterable[Tuple[str, ImageMeta]]) -> None:
     paths: List[str] = []
@@ -276,6 +297,7 @@ def init_rclip(
   exclude_dir: Optional[List[str]] = None,
   no_indexing: bool = False,
   enable_raw_support: bool = False,
+  max_image_pixels: helpers.MaxImagePixels = helpers.AUTO_MAX_IMAGE_PIXELS,
 ):
   datadir = helpers.get_app_datadir()
   db_path = datadir / "db.sqlite3"
@@ -289,6 +311,7 @@ def init_rclip(
     indexing_batch_size=indexing_batch_size,
     exclude_dirs=exclude_dir,
     enable_raw_support=enable_raw_support,
+    max_image_pixels=max_image_pixels,
   )
 
   if not no_indexing:
@@ -337,6 +360,7 @@ def main():
     args.exclude_dir,
     args.no_indexing,
     args.experimental_raw_support,
+    args.max_image_megapixels,
   )
 
   try:

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -135,7 +135,7 @@ class RClip:
       except (PIL.Image.DecompressionBombError, PIL.Image.DecompressionBombWarning) as ex:
         # backstop for formats whose true size only surfaces while decoding in the worker
         print(
-          _too_large_message(path, helpers._parse_bomb_pixels(ex), helpers.get_max_image_pixels() or 0), file=sys.stderr
+          _too_large_message(path, helpers.parse_bomb_pixels(ex), helpers.get_max_image_pixels() or 0), file=sys.stderr
         )
       except MemoryError:
         print(f"skipping {path}: ran out of memory while processing it", file=sys.stderr)

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -148,9 +148,14 @@ class Model:
       file_multipliers, file_paths = zip(*files) if files else ((), ())
       url_multipliers, url_paths = zip(*urls) if urls else ((), ())
       try:
-        images = [helpers.download_image(url_path) for url_path in url_paths] + [
-          helpers.read_image(file_path) for file_path in file_paths
+        # query images are explicitly chosen by the user and decoded one at a time, so the indexing
+        # memory cap doesn't apply; read them as trusted (bypassing the cap) and only fail on a
+        # genuine out-of-memory while decoding.
+        images = [helpers.download_image(url_path, trusted=True) for url_path in url_paths] + [
+          helpers.read_image(file_path, trusted=True) for file_path in file_paths
         ]
+        image_multipliers = np.array(url_multipliers + file_multipliers)
+        image_features = np.add.reduce(self.compute_image_features(images) * image_multipliers.reshape(-1, 1))
       except FileNotFoundError as error:
         print(f'File "{error.filename}" not found. Check if you have typos in the filename.')
         import sys
@@ -161,8 +166,11 @@ class Model:
         import sys
 
         sys.exit(1)
-      image_multipliers = np.array(url_multipliers + file_multipliers)
-      image_features = np.add.reduce(self.compute_image_features(images) * image_multipliers.reshape(-1, 1))
+      except (MemoryError, Image.DecompressionBombError, Image.DecompressionBombWarning):
+        print("A query image is too large to process: ran out of memory while decoding it.")
+        import sys
+
+        sys.exit(1)
 
     if phrases:
       phrase_multipliers, phrase_queries = zip(*phrases)

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -166,8 +166,13 @@ class Model:
         import sys
 
         sys.exit(1)
-      except (MemoryError, Image.DecompressionBombError, Image.DecompressionBombWarning):
-        print("A query image is too large to process: ran out of memory while decoding it.")
+      except (Image.DecompressionBombError, Image.DecompressionBombWarning):
+        print("A query image is too large to process.")
+        import sys
+
+        sys.exit(1)
+      except MemoryError:
+        print("Ran out of memory while decoding a query image.")
         import sys
 
         sys.exit(1)

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -3,7 +3,8 @@ import io
 import os
 import pathlib
 import textwrap
-from typing import IO, cast
+import warnings
+from typing import IO, Optional, Union, cast
 from PIL import Image, UnidentifiedImageError
 import re
 import numpy as np
@@ -19,7 +20,88 @@ DOWNLOAD_TIMEOUT_SECONDS = 60
 WIN_ABSOLUTE_FILE_PATH_REGEX = re.compile(r"^[a-z]:\\", re.I)
 DEFAULT_TERMINAL_TEXT_WIDTH = 100
 
+# PIL's historic decompression-bomb limit; we never set our cap below this so that
+# ordinary large photos (high-MP panoramas, scans) always index.
+MIN_MAX_IMAGE_PIXELS = 89_478_485
+# the memory-aware default caps a single decoded image at this fraction of total RAM,
+# divided across the concurrent loader threads so that several big images can decode at once.
+_MAX_IMAGE_PIXELS_MEMORY_FRACTION = 0.5
+# a decoded pixel costs ~3 bytes (RGB), but decoding and our preprocessing keep extra copies
+# around, so we budget conservatively.
+_DECODED_BYTES_PER_PIXEL = 4
+
+# "auto" means "compute the memory-aware default"; an int is an explicit cap; None disables the
+# cap entirely (for power users indexing a trusted tree of gigapixel images).
+AUTO_MAX_IMAGE_PIXELS = "auto"
+MaxImagePixels = Union[str, int, None]
+
 _image_loading_configured = False
+_max_image_pixels: Optional[int] = MIN_MAX_IMAGE_PIXELS
+
+
+class ImageTooLargeError(Exception):
+  """Raised when an image's pixel count exceeds the configured limit, before it gets decoded."""
+
+  def __init__(self, path: str, pixels: int, limit: int):
+    self.path = path
+    self.pixels = pixels
+    self.limit = limit
+    super().__init__(f"{path} has {pixels} pixels, which exceeds the limit of {limit} pixels")
+
+
+def _get_total_memory_bytes() -> Optional[int]:
+  """Best-effort total physical RAM, cross-platform; returns None if it can't be determined."""
+  try:
+    if IS_WINDOWS:
+      import ctypes
+
+      class MEMORYSTATUSEX(ctypes.Structure):
+        _fields_ = [
+          ("dwLength", ctypes.c_ulong),
+          ("dwMemoryLoad", ctypes.c_ulong),
+          ("ullTotalPhys", ctypes.c_ulonglong),
+          ("ullAvailPhys", ctypes.c_ulonglong),
+          ("ullTotalPageFile", ctypes.c_ulonglong),
+          ("ullAvailPageFile", ctypes.c_ulonglong),
+          ("ullTotalVirtual", ctypes.c_ulonglong),
+          ("ullAvailVirtual", ctypes.c_ulonglong),
+          ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+        ]
+
+      stat = MEMORYSTATUSEX()
+      stat.dwLength = ctypes.sizeof(MEMORYSTATUSEX)
+      # windll only exists on Windows; getattr keeps the type checker happy on other platforms
+      getattr(ctypes, "windll").kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))
+      return int(stat.ullTotalPhys)
+    return os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+  except (ValueError, OSError, AttributeError):
+    return None
+
+
+def compute_default_max_image_pixels(workers: int) -> int:
+  """Picks a decompression-bomb cap from the machine's RAM so we attempt only images we can
+  reasonably decode, never going below MIN_MAX_IMAGE_PIXELS so normal large photos still index."""
+  total = _get_total_memory_bytes()
+  if not total:
+    return MIN_MAX_IMAGE_PIXELS
+  estimate = int(total * _MAX_IMAGE_PIXELS_MEMORY_FRACTION / (max(1, workers) * _DECODED_BYTES_PER_PIXEL))
+  return max(MIN_MAX_IMAGE_PIXELS, estimate)
+
+
+def get_max_image_pixels() -> Optional[int]:
+  return _max_image_pixels
+
+
+def configure_max_image_pixels(value: MaxImagePixels, workers: int) -> None:
+  """Resolves and applies the image pixel cap. ``value`` is "auto" (memory-aware default),
+  an explicit int, or None to disable the cap. Also mirrors it onto PIL as a defense-in-depth
+  backstop for formats that don't expose their size before decoding."""
+  global _max_image_pixels
+  if value == AUTO_MAX_IMAGE_PIXELS:
+    _max_image_pixels = compute_default_max_image_pixels(workers)
+  else:
+    _max_image_pixels = cast(Optional[int], value)
+  Image.MAX_IMAGE_PIXELS = _max_image_pixels
 
 
 def _ensure_image_loading_configured() -> None:
@@ -33,6 +115,11 @@ def _ensure_image_loading_configured() -> None:
 
   setattr(ImageFile, "LOAD_TRUNCATED_IMAGES", True)
   register_heif_opener()
+  # PIL only *warns* at MAX_IMAGE_PIXELS and *raises* at 2x; turn the warning into an error so we
+  # get a single, clean threshold (the cap) with no raw PIL warning text leaking to the console.
+  warnings.filterwarnings("error", category=Image.DecompressionBombWarning)
+  # apply the cap onto PIL even if configure_max_image_pixels was never called (e.g. URL queries)
+  Image.MAX_IMAGE_PIXELS = _max_image_pixels
   _image_loading_configured = True
 
 
@@ -83,6 +170,20 @@ def positive_int_arg_type(arg: str) -> int:
   if arg_int < 1:
     raise argparse.ArgumentTypeError("should be >0")
   return arg_int
+
+
+def max_image_megapixels_arg_type(arg: str) -> MaxImagePixels:
+  """Parses the --max-image-megapixels value (in megapixels) into an internal pixel count;
+  returns AUTO_MAX_IMAGE_PIXELS for "auto" and None for the "disable the limit" keywords.
+  argparse also runs this on the string default, so "auto" must pass through cleanly."""
+  if arg.lower() == AUTO_MAX_IMAGE_PIXELS:
+    return AUTO_MAX_IMAGE_PIXELS
+  if arg.lower() in ("none", "off", "disable", "disabled", "0"):
+    return None
+  megapixels = float(arg)
+  if megapixels <= 0:
+    raise argparse.ArgumentTypeError('should be >0, "auto", or "none" to disable the limit')
+  return round(megapixels * 1_000_000)
 
 
 def get_terminal_text_width() -> int:
@@ -206,6 +307,15 @@ def init_arg_parser() -> argparse.ArgumentParser:
     default=False,
     help="enables support for RAW images (ARW, CR2, and DNG are supported)",
   )
+  parser.add_argument(
+    "--max-image-megapixels",
+    metavar="MP",
+    type=max_image_megapixels_arg_type,
+    default=AUTO_MAX_IMAGE_PIXELS,
+    help="maximum size, in megapixels, an image may have to be indexed; larger images are skipped to"
+    " avoid running out of memory on huge or maliciously crafted images;"
+    ' pass "none" to disable the limit; default: chosen automatically based on available memory',
+  )
   return parser
 
 
@@ -250,6 +360,15 @@ def read_raw_image_file(path: str):
   return Image.fromarray(np.array(rgb))
 
 
+_BOMB_PIXELS_RE = re.compile(r"Image size \((\d+) pixels\)")
+
+
+def _parse_bomb_pixels(error: Exception) -> int:
+  """Pulls the pixel count out of PIL's decompression-bomb message; 0 if it can't be parsed."""
+  match = _BOMB_PIXELS_RE.search(str(error))
+  return int(match.group(1)) if match else 0
+
+
 def read_image(query: str) -> Image.Image:
   _ensure_image_loading_configured()
   path = str.removeprefix(query, "file://")
@@ -258,11 +377,17 @@ def read_image(query: str) -> Image.Image:
     if file_ext in IMAGE_RAW_EXT:
       image = read_raw_image_file(path)
     else:
+      # Image.open only reads the header and runs PIL's decompression-bomb check there, so oversized
+      # images are rejected before we ever decode and allocate memory for them.
       image = Image.open(path)
   except UnidentifiedImageError as e:
     # by default the filename on the UnidentifiedImageError is None
     e.filename = path
     raise e
+  except (Image.DecompressionBombError, Image.DecompressionBombWarning) as e:
+    # we turn PIL's warning into an error too (see _ensure_image_loading_configured), so this catches
+    # both PIL tiers; re-raise as our own type so callers get a clean, friendly message.
+    raise ImageTooLargeError(path, _parse_bomb_pixels(e), _max_image_pixels or 0) from e
   return image
 
 

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -183,7 +183,10 @@ def max_image_megapixels_arg_type(arg: str) -> MaxImagePixels:
     return AUTO_MAX_IMAGE_PIXELS
   if arg.lower() in ("none", "off", "disable", "disabled", "0"):
     return None
-  megapixels = float(arg)
+  try:
+    megapixels = float(arg)
+  except ValueError:
+    raise argparse.ArgumentTypeError('should be a number, "auto", or "none" to disable the limit')
   if megapixels <= 0:
     raise argparse.ArgumentTypeError('should be >0, "auto", or "none" to disable the limit')
   return round(megapixels * 1_000_000)
@@ -335,9 +338,10 @@ def download_image(url: str, *, trusted: bool = False) -> Image.Image:
   # a query image URL is chosen by the user, so bypass the cap when trusted (see read_image)
   limit_ctx = image_pixel_limit_disabled() if trusted else contextlib.nullcontext()
   with limit_ctx:
-    img = Image.open(
-      cast(IO[bytes], requests.get(url, headers=headers, stream=True, timeout=DOWNLOAD_TIMEOUT_SECONDS).raw)
-    )
+    response = requests.get(url, headers=headers, stream=True, timeout=DOWNLOAD_TIMEOUT_SECONDS)
+    img = Image.open(cast(IO[bytes], response.raw))
+    img.load()
+  response.close()
   return img
 
 

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -1,4 +1,5 @@
 import argparse
+import contextlib
 import io
 import os
 import pathlib
@@ -70,8 +71,10 @@ def _get_total_memory_bytes() -> Optional[int]:
 
       stat = MEMORYSTATUSEX()
       stat.dwLength = ctypes.sizeof(MEMORYSTATUSEX)
-      # windll only exists on Windows; getattr keeps the type checker happy on other platforms
-      getattr(ctypes, "windll").kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))
+      # windll only exists on Windows; getattr keeps the type checker happy on other platforms.
+      # GlobalMemoryStatusEx returns 0 on failure, in which case stat is left uninitialized.
+      if not getattr(ctypes, "windll").kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):
+        return None
       return int(stat.ullTotalPhys)
     return os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
   except (ValueError, OSError, AttributeError):
@@ -320,7 +323,7 @@ def init_arg_parser() -> argparse.ArgumentParser:
 
 
 # See: https://meta.wikimedia.org/wiki/User-Agent_policy
-def download_image(url: str) -> Image.Image:
+def download_image(url: str, *, trusted: bool = False) -> Image.Image:
   import requests
 
   _ensure_image_loading_configured()
@@ -329,9 +332,12 @@ def download_image(url: str) -> Image.Image:
   if length := check_size.headers.get("Content-Length"):
     if int(length) > MAX_DOWNLOAD_SIZE_BYTES:
       raise ValueError(f"Avoiding download of large ({length} byte) file.")
-  img = Image.open(
-    cast(IO[bytes], requests.get(url, headers=headers, stream=True, timeout=DOWNLOAD_TIMEOUT_SECONDS).raw)
-  )
+  # a query image URL is chosen by the user, so bypass the cap when trusted (see read_image)
+  limit_ctx = image_pixel_limit_disabled() if trusted else contextlib.nullcontext()
+  with limit_ctx:
+    img = Image.open(
+      cast(IO[bytes], requests.get(url, headers=headers, stream=True, timeout=DOWNLOAD_TIMEOUT_SECONDS).raw)
+    )
   return img
 
 
@@ -363,23 +369,40 @@ def read_raw_image_file(path: str):
 _BOMB_PIXELS_RE = re.compile(r"Image size \((\d+) pixels\)")
 
 
-def _parse_bomb_pixels(error: Exception) -> int:
+def parse_bomb_pixels(error: Exception) -> int:
   """Pulls the pixel count out of PIL's decompression-bomb message; 0 if it can't be parsed."""
   match = _BOMB_PIXELS_RE.search(str(error))
   return int(match.group(1)) if match else 0
 
 
-def read_image(query: str) -> Image.Image:
+@contextlib.contextmanager
+def image_pixel_limit_disabled():
+  """Temporarily lifts the decompression-bomb cap. Used for images the user explicitly chose as a
+  query: they are trusted and decoded one at a time, so the indexing memory cap doesn't apply.
+  Only safe on the single-threaded query path, since Image.MAX_IMAGE_PIXELS is process-global."""
+  previous = Image.MAX_IMAGE_PIXELS
+  Image.MAX_IMAGE_PIXELS = None
+  try:
+    yield
+  finally:
+    Image.MAX_IMAGE_PIXELS = previous
+
+
+def read_image(query: str, *, trusted: bool = False) -> Image.Image:
   _ensure_image_loading_configured()
   path = str.removeprefix(query, "file://")
+  # an explicit query image is chosen by the user and decoded one at a time, so the indexing memory
+  # cap doesn't apply; read it as trusted and bypass the cap so any size the user points at works.
+  limit_ctx = image_pixel_limit_disabled() if trusted else contextlib.nullcontext()
   try:
-    file_ext = get_file_extension(path)
-    if file_ext in IMAGE_RAW_EXT:
-      image = read_raw_image_file(path)
-    else:
-      # Image.open only reads the header and runs PIL's decompression-bomb check there, so oversized
-      # images are rejected before we ever decode and allocate memory for them.
-      image = Image.open(path)
+    with limit_ctx:
+      file_ext = get_file_extension(path)
+      if file_ext in IMAGE_RAW_EXT:
+        image = read_raw_image_file(path)
+      else:
+        # Image.open only reads the header and runs PIL's decompression-bomb check there, so oversized
+        # images are rejected before we ever decode and allocate memory for them.
+        image = Image.open(path)
   except UnidentifiedImageError as e:
     # by default the filename on the UnidentifiedImageError is None
     e.filename = path
@@ -387,7 +410,7 @@ def read_image(query: str) -> Image.Image:
   except (Image.DecompressionBombError, Image.DecompressionBombWarning) as e:
     # we turn PIL's warning into an error too (see _ensure_image_loading_configured), so this catches
     # both PIL tiers; re-raise as our own type so callers get a clean, friendly message.
-    raise ImageTooLargeError(path, _parse_bomb_pixels(e), _max_image_pixels or 0) from e
+    raise ImageTooLargeError(path, parse_bomb_pixels(e), _max_image_pixels or 0) from e
   return image
 
 

--- a/rclip/utils/preview.py
+++ b/rclip/utils/preview.py
@@ -46,7 +46,9 @@ def _get_preview_dimensions(width_px: int, height_px: int) -> tuple[str, str]:
 
 
 def preview(filepath: str, img_height_px: int):
-  with read_image(filepath) as img:
+  # preview images are displayed one at a time and the user opted into viewing them, so the
+  # indexing memory cap doesn't apply; read as trusted like query images.
+  with read_image(filepath, trusted=True) as img:
     if img_height_px >= img.height:
       width_px, height_px = img.width, img.height
     else:

--- a/tests/unit/test_index_images.py
+++ b/tests/unit/test_index_images.py
@@ -18,6 +18,12 @@ def _fail_on_b(path: str) -> Image.Image:
   return Image.new("RGB", (1, 1))
 
 
+def _too_large_on_b(path: str) -> Image.Image:
+  if path == "b.jpg":
+    raise helpers.ImageTooLargeError(path, 200_000_000, 100_000_000)
+  return Image.new("RGB", (1, 1))
+
+
 def test_load_images_preserves_order_and_skips_failures(monkeypatch):
   monkeypatch.setattr(helpers, "_ensure_image_loading_configured", lambda: None)
   monkeypatch.setattr(helpers, "read_image", _fail_on_b)
@@ -36,6 +42,29 @@ def test_load_images_preserves_order_and_skips_failures(monkeypatch):
   assert [(path, meta) for path, meta, _image in loaded] == [("a.jpg", meta_a), ("c.jpg", meta_c)]
   # the loader threads preprocess the images, so it yields ready-to-encode CLIP tensors
   assert all(isinstance(image, np.ndarray) and image.shape == (3, 256, 256) for _path, _meta, image in loaded)
+
+
+def test_load_images_skips_images_that_are_too_large(monkeypatch, capsys):
+  monkeypatch.setattr(helpers, "_ensure_image_loading_configured", lambda: None)
+  monkeypatch.setattr(helpers, "read_image", _too_large_on_b)
+
+  meta_a = ImageMeta(modified_at=1.0, size=100)
+  meta_b = ImageMeta(modified_at=2.0, size=200)
+  meta_c = ImageMeta(modified_at=3.0, size=300)
+
+  rclip = _make_rclip(Mock(), Mock())
+  try:
+    loaded = list(rclip._load_images([("a.jpg", meta_a), ("b.jpg", meta_b), ("c.jpg", meta_c)]))
+  finally:
+    rclip.close()
+
+  # the too-large image is dropped, the rest survive in order
+  assert [path for path, _meta, _image in loaded] == ["a.jpg", "c.jpg"]
+  # the user gets a friendly, actionable message naming the file and the limit
+  err = capsys.readouterr().err
+  assert "skipping b.jpg" in err
+  assert "too large" in err
+  assert "--max-image-megapixels" in err
 
 
 def test_index_images_keeps_meta_aligned_when_an_image_fails_to_load(monkeypatch):

--- a/tests/unit/test_max_image_pixels.py
+++ b/tests/unit/test_max_image_pixels.py
@@ -1,0 +1,58 @@
+import pytest
+from PIL import Image
+
+from rclip.utils import helpers
+
+
+@pytest.fixture(autouse=True)
+def _restore_cap():
+  # the cap is process-global (it is mirrored onto PIL), so reset it after each test
+  original = helpers.get_max_image_pixels()
+  yield
+  helpers.configure_max_image_pixels(original, workers=1)
+
+
+def test_default_cap_never_drops_below_the_floor():
+  # even with many workers, ordinary large photos must still index
+  assert helpers.compute_default_max_image_pixels(64) >= helpers.MIN_MAX_IMAGE_PIXELS
+
+
+def test_default_cap_falls_back_to_the_floor_without_memory_info(monkeypatch):
+  monkeypatch.setattr(helpers, "_get_total_memory_bytes", lambda: None)
+  assert helpers.compute_default_max_image_pixels(16) == helpers.MIN_MAX_IMAGE_PIXELS
+
+
+def test_explicit_cap_rejects_oversized_image_before_decoding(tmp_path):
+  helpers.configure_max_image_pixels(100, workers=1)
+  path = str(tmp_path / "big.png")
+  Image.new("RGB", (50, 50)).save(path)  # 2500 px > 100
+
+  with pytest.raises(helpers.ImageTooLargeError) as exc:
+    helpers.read_image(path)
+  assert exc.value.pixels == 2500
+  assert exc.value.limit == 100
+
+
+def test_cap_allows_images_within_the_limit(tmp_path):
+  helpers.configure_max_image_pixels(100, workers=1)
+  path = str(tmp_path / "small.png")
+  Image.new("RGB", (5, 5)).save(path)  # 25 px < 100
+  assert helpers.read_image(path).size == (5, 5)
+
+
+def test_disabled_cap_opens_any_image(tmp_path):
+  helpers.configure_max_image_pixels(None, workers=1)
+  assert helpers.get_max_image_pixels() is None
+  path = str(tmp_path / "big.png")
+  Image.new("RGB", (50, 50)).save(path)
+  assert helpers.read_image(path).size == (50, 50)
+
+
+def test_arg_type_parses_disable_keywords_and_megapixels():
+  assert helpers.max_image_megapixels_arg_type("none") is None
+  assert helpers.max_image_megapixels_arg_type("0") is None
+  # the value is given in megapixels and converted to an internal pixel count
+  assert helpers.max_image_megapixels_arg_type("500") == 500_000_000
+  assert helpers.max_image_megapixels_arg_type("89.5") == 89_500_000
+  with pytest.raises(Exception):
+    helpers.max_image_megapixels_arg_type("-5")

--- a/tests/unit/test_max_image_pixels.py
+++ b/tests/unit/test_max_image_pixels.py
@@ -40,6 +40,23 @@ def test_cap_allows_images_within_the_limit(tmp_path):
   assert helpers.read_image(path).size == (5, 5)
 
 
+def test_trusted_read_bypasses_the_cap_and_restores_it(tmp_path):
+  helpers.configure_max_image_pixels(100, workers=1)
+  path = str(tmp_path / "big.png")
+  Image.new("RGB", (50, 50)).save(path)  # 2500 px > 100
+
+  # a normal (untrusted) read is rejected
+  with pytest.raises(helpers.ImageTooLargeError):
+    helpers.read_image(path)
+
+  # a trusted read (an explicit query image) opens regardless of the cap
+  assert helpers.read_image(path, trusted=True).size == (50, 50)
+
+  # and the cap is left untouched afterwards
+  assert helpers.get_max_image_pixels() == 100
+  assert Image.MAX_IMAGE_PIXELS == 100
+
+
 def test_disabled_cap_opens_any_image(tmp_path):
   helpers.configure_max_image_pixels(None, workers=1)
   assert helpers.get_max_image_pixels() is None

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -7,7 +7,7 @@ from rclip.utils import preview as preview_module
 
 
 def test_preview_uses_terminal_cell_dimensions_when_available(monkeypatch, capsys):
-  monkeypatch.setattr(preview_module, "read_image", lambda _filepath: Image.new("RGB", (200, 100), "red"))
+  monkeypatch.setattr(preview_module, "read_image", lambda _filepath, **_kw: Image.new("RGB", (200, 100), "red"))
   monkeypatch.setattr(preview_module, "_get_preview_dimensions", lambda _width, _height: ("10", "5"))
 
   preview_module.preview("cat.jpg", 50)


### PR DESCRIPTION
## How does this PR impact the user?

1. On machines with lots of RAM, `rclip` will start indexing high-resolution (>200 MP) images without complaining.
2. On machines with little RAM, `rclip` will be less likely to OOM because it will be refusing to index too large images.
3. User will be able to adjust or disable the limit (to bypass the restriction for a single image or if they are ok for rclip to start swapping).
4. Error messages displayed when rclip skips large images are now more human-friendly and suggest to raise the limit if the user needs to index the image.

## Description

- [x] add `--max-image-megapixels` CLI argument (number in MP, `"auto"`, or `"none"`)
- [x] compute a memory-aware default cap based on available RAM, with a floor of ~89 MP
- [x] reject oversized images before decoding, with a friendly skip message
- [x] mirror the cap onto PIL's `Image.MAX_IMAGE_PIXELS` as a backstop
- [x] handle `MemoryError` and `DecompressionBombError` gracefully on the indexing path
- [x] bypass the cap for query and preview images (`trusted=True`)
- [x] document `--max-image-megapixels` in the README
- [x] add tests

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
