### PR TITLE
fix: daily macOS CI test

### DIFF
--- a/.github/workflows/test-latest-stable-release.yaml
+++ b/.github/workflows/test-latest-stable-release.yaml
@@ -42,8 +42,6 @@ jobs:
 
   brew:
     needs: get_last_release_tag
-    env:
-      HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
     strategy:
       matrix:
         # FIXME: the test fails on linuxbrew because it rclip from linuxbrew
@@ -64,6 +62,8 @@ jobs:
           echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/runner/.bashrc
       - run: brew update && brew upgrade
       - run: brew install yurijmikhalevich/tap/rclip
+        env:
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
         # overriding shell to ensure it reads `.bashrc`
         shell: bash -ieo pipefail {0}
       - uses: ./.github/actions/test-system-rclip

--- a/.github/workflows/test-latest-stable-release.yaml
+++ b/.github/workflows/test-latest-stable-release.yaml
@@ -43,7 +43,7 @@ jobs:
   brew:
     needs: get_last_release_tag
     env:
-      HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
+      HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
     strategy:
       matrix:
         # FIXME: the test fails on linuxbrew because it rclip from linuxbrew

--- a/.github/workflows/test-latest-stable-release.yaml
+++ b/.github/workflows/test-latest-stable-release.yaml
@@ -64,7 +64,7 @@ jobs:
           brew update
           brew install yurijmikhalevich/tap/rclip
           # upgrade only rclip and its dependencies to test with latest packages
-          brew upgrade $(brew deps --include-build yurijmikhalevich/tap/rclip) yurijmikhalevich/tap/rclip
+          brew upgrade $(brew deps yurijmikhalevich/tap/rclip) yurijmikhalevich/tap/rclip
         env:
           HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
         # overriding shell to ensure it reads `.bashrc`

--- a/.github/workflows/test-latest-stable-release.yaml
+++ b/.github/workflows/test-latest-stable-release.yaml
@@ -60,10 +60,13 @@ jobs:
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           echo >> /home/runner/.bashrc
           echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/runner/.bashrc
-      - run: brew update && brew upgrade
+      - run: |
+          brew update
+          brew install yurijmikhalevich/tap/rclip
+          # upgrade only rclip and its dependencies to test with latest packages
+          brew upgrade $(brew deps --include-build yurijmikhalevich/tap/rclip) yurijmikhalevich/tap/rclip
         env:
           HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
-      - run: brew install yurijmikhalevich/tap/rclip
         # overriding shell to ensure it reads `.bashrc`
         shell: bash -ieo pipefail {0}
       - uses: ./.github/actions/test-system-rclip

--- a/.github/workflows/test-latest-stable-release.yaml
+++ b/.github/workflows/test-latest-stable-release.yaml
@@ -61,9 +61,9 @@ jobs:
           echo >> /home/runner/.bashrc
           echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/runner/.bashrc
       - run: brew update && brew upgrade
-      - run: brew install yurijmikhalevich/tap/rclip
         env:
           HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
+      - run: brew install yurijmikhalevich/tap/rclip
         # overriding shell to ensure it reads `.bashrc`
         shell: bash -ieo pipefail {0}
       - uses: ./.github/actions/test-system-rclip

--- a/.github/workflows/test-latest-stable-release.yaml
+++ b/.github/workflows/test-latest-stable-release.yaml
@@ -65,8 +65,6 @@ jobs:
           brew install yurijmikhalevich/tap/rclip
           # upgrade only rclip and its dependencies to test with latest packages
           brew upgrade $(brew deps yurijmikhalevich/tap/rclip) yurijmikhalevich/tap/rclip
-        env:
-          HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
         # overriding shell to ensure it reads `.bashrc`
         shell: bash -ieo pipefail {0}
       - uses: ./.github/actions/test-system-rclip

--- a/.github/workflows/test-latest-stable-release.yaml
+++ b/.github/workflows/test-latest-stable-release.yaml
@@ -42,6 +42,8 @@ jobs:
 
   brew:
     needs: get_last_release_tag
+    env:
+      HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
     strategy:
       matrix:
         # FIXME: the test fails on linuxbrew because it rclip from linuxbrew


### PR DESCRIPTION
## How does this PR impact the user?

The user will have more stable rclip experience because we will detect all of the failures sooner.

## Description

- [x] only upgrade rclip's dependency instead of upgrading all packages in the runner

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
