### PR TITLE
feat: enable daily rclip testing on brew for Linux

### DIFF
--- a/.github/workflows/test-latest-stable-release.yaml
+++ b/.github/workflows/test-latest-stable-release.yaml
@@ -44,11 +44,7 @@ jobs:
     needs: get_last_release_tag
     strategy:
       matrix:
-        # FIXME: the test fails on linuxbrew because it rclip from linuxbrew
-        # produces a slightly different output; maybe, because we built pytorch
-        # slightly differently for linuxbrew
-        # os: [ubuntu-22.04, macos-15]
-        os: [macos-15]
+        os: [ubuntu-22.04, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## How does this PR impact the user?

Issues with running rclip on brew for Linux will be found and fixed sooner.

## Description

Enable testing rclip on brew for Linux in a daily CI run.

## Limitations

N/A

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
