### PR TITLE
fix: skip macOS metadata and hidden files on external drives (#303)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Run `rclip --help` (or `rclip -h`) to see this list in your terminal. The positi
 | `--no-indexing`, `--skip-index`, `--skip-indexing`, `-n` | Skip updating the index. Use only when no images were added, changed, or removed since the last run. |
 | `--indexing-batch-size`, `-b` `N` | The size of the image batch used when updating the search index. Larger values may slightly improve indexing speed on some hardware but increase RAM usage. Default: `8`. |
 | `--exclude-dir` `DIR` | Directory to exclude from search. Can be used multiple times. Specifying this overrides the default of `@eaDir`, `node_modules`, and `.git`. |
+| `--include-hidden` | Index dot-prefixed hidden files and directories (e.g. `.DS_Store`, `._IMG_1234.JPG`, `.Spotlight-V100`). Skipped by default since they are usually OS metadata rather than user files. |
 | `--experimental-raw-support` | Enable support for RAW images (`arw`, `cr2`, and `dng` are supported). |
 | `--max-image-megapixels` `MP` | Maximum size, in megapixels, an image may have to be indexed. Larger images are skipped to avoid running out of memory on huge or maliciously crafted images. Pass `none` to disable the limit. Default: chosen automatically based on the available memory. |
 | `--version`, `-v` | Print the **rclip** version and exit. |

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Run `rclip --help` (or `rclip -h`) to see this list in your terminal. The positi
 | `--preview-height`, `-H` `PX` | Preview height in pixels. Default: `400`. |
 | `--no-indexing`, `--skip-index`, `--skip-indexing`, `-n` | Skip updating the index. Use only when no images were added, changed, or removed since the last run. |
 | `--indexing-batch-size`, `-b` `N` | The size of the image batch used when updating the search index. Larger values may slightly improve indexing speed on some hardware but increase RAM usage. Default: `8`. |
-| `--exclude-dir` `DIR` | Directory to exclude from search. Can be used multiple times. Specifying this overrides the default of `@eaDir`, `node_modules`, and `.git`. |
+| `--exclude-dir` `DIR` | Directory to exclude from search. Can be used multiple times. Specifying this overrides the default of `@eaDir`, `node_modules`, `.git`, and `System Volume Information`. |
 | `--include-hidden` | Index dot-prefixed hidden files and directories (e.g. `.DS_Store`, `._IMG_1234.JPG`, `.Spotlight-V100`). Skipped by default since they are usually OS metadata rather than user files. |
 | `--experimental-raw-support` | Enable support for RAW images (`arw`, `cr2`, and `dng` are supported). |
 | `--max-image-megapixels` `MP` | Maximum size, in megapixels, an image may have to be indexed. Larger images are skipped to avoid running out of memory on huge or maliciously crafted images. Pass `none` to disable the limit. Default: chosen automatically based on the available memory. |

--- a/rclip/fs.py
+++ b/rclip/fs.py
@@ -5,11 +5,15 @@ COUNT_FILES_UPDATE_EVERY = 10_000
 
 
 def count_files(
-  directory: str, exclude_dir_re: Pattern[str], file_re: Pattern[str], on_change: Callable[[int], None]
+  directory: str,
+  exclude_dir_re: Pattern[str],
+  file_re: Pattern[str],
+  on_change: Callable[[int], None],
+  skip_hidden: bool = True,
 ) -> None:
   prev_update_count = 0
   count = 0
-  for _ in walk(directory, exclude_dir_re, file_re):
+  for _ in walk(directory, exclude_dir_re, file_re, skip_hidden):
     count += 1
     if count - prev_update_count >= COUNT_FILES_UPDATE_EVERY:
       on_change(count)
@@ -21,6 +25,7 @@ def walk(
   directory: str,
   exclude_dir_re: Pattern[str],
   file_re: Pattern[str],
+  skip_hidden: bool = True,
 ):
   """Walks through a directory recursively and yields files that match the given regex"""
   dirs_to_process = [directory]
@@ -28,6 +33,8 @@ def walk(
     dir = dirs_to_process.pop()
     with os.scandir(dir) as it:
       for entry in it:
+        if skip_hidden and entry.name.startswith("."):
+          continue
         if entry.is_dir():
           if not exclude_dir_re.match(entry.path):
             dirs_to_process.append(entry.path)

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -57,7 +57,7 @@ def _read_and_preprocess(path: str) -> Tuple[str, str, npt.NDArray[np.float32]]:
 
 
 class RClip:
-  EXCLUDE_DIRS_DEFAULT = ["@eaDir", "node_modules", ".git"]
+  EXCLUDE_DIRS_DEFAULT = ["@eaDir", "node_modules", ".git", "System Volume Information"]
   DB_IMAGES_BEFORE_COMMIT = 50_000
   # how many indexing batches to keep loading ahead of the model; preprocessed
   # images are small (a few hundred KB each), so a few batches of look-ahead
@@ -77,11 +77,13 @@ class RClip:
     exclude_dirs: Optional[List[str]],
     enable_raw_support: bool = False,
     max_image_pixels: helpers.MaxImagePixels = helpers.AUTO_MAX_IMAGE_PIXELS,
+    include_hidden: bool = False,
   ):
     self._model = model_instance
     self._db = database
     self._indexing_batch_size = indexing_batch_size
     self._enable_raw_support = enable_raw_support
+    self._skip_hidden = not include_hidden
 
     supported_image_ext = IMAGE_EXT + (IMAGE_RAW_EXT if enable_raw_support else [])
     self._image_regex = re.compile(f"^.+\\.({'|'.join(supported_image_ext)})$", re.I)
@@ -214,7 +216,7 @@ class RClip:
     """Walks the directory and yields (path, meta) for every image that needs (re)indexing, skipping
     the ones already up to date in the database. Advances the progress bar once per scanned file."""
     images_processed = 0
-    for entry in fs.walk(directory, self._exclude_dir_regex, self._image_regex):
+    for entry in fs.walk(directory, self._exclude_dir_regex, self._image_regex, self._skip_hidden):
       filepath = entry.path
 
       if self._enable_raw_support:
@@ -260,7 +262,7 @@ class RClip:
 
       counter_thread = threading.Thread(
         target=fs.count_files,
-        args=(directory, self._exclude_dir_regex, self._image_regex, update_total_images),
+        args=(directory, self._exclude_dir_regex, self._image_regex, update_total_images, self._skip_hidden),
       )
       counter_thread.start()
 
@@ -318,6 +320,7 @@ def init_rclip(
   no_indexing: bool = False,
   enable_raw_support: bool = False,
   max_image_pixels: helpers.MaxImagePixels = helpers.AUTO_MAX_IMAGE_PIXELS,
+  include_hidden: bool = False,
 ):
   datadir = helpers.get_app_datadir()
   db_path = datadir / "db.sqlite3"
@@ -332,6 +335,7 @@ def init_rclip(
     exclude_dirs=exclude_dir,
     enable_raw_support=enable_raw_support,
     max_image_pixels=max_image_pixels,
+    include_hidden=include_hidden,
   )
 
   if not no_indexing:
@@ -381,6 +385,7 @@ def main():
     args.no_indexing,
     args.experimental_raw_support,
     args.max_image_megapixels,
+    args.include_hidden,
   )
 
   try:

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -330,7 +330,16 @@ def init_arg_parser() -> argparse.ArgumentParser:
     "--exclude-dir",
     action="append",
     help="dir to exclude from search, can be used multiple times;"
-    ' adding this argument overrides the default of ("@eaDir", "node_modules", ".git")',
+    ' adding this argument overrides the default of'
+    ' ("@eaDir", "node_modules", ".git", "System Volume Information")',
+  )
+  parser.add_argument(
+    "--include-hidden",
+    action="store_true",
+    default=False,
+    help="index dot-prefixed hidden files and directories"
+    " (e.g. .DS_Store, ._IMG_1234.JPG, .Spotlight-V100);"
+    " by default they are skipped since they are usually OS metadata rather than user files",
   )
   parser.add_argument(
     "--experimental-raw-support",

--- a/tests/unit/test_fs.py
+++ b/tests/unit/test_fs.py
@@ -1,0 +1,49 @@
+import os
+import re
+from pathlib import Path
+
+from rclip import fs
+
+IMAGE_RE = re.compile(r"^.+\.(jpg|jpeg|png)$", re.I)
+EXCLUDE_DIR_RE = re.compile(rf"^.+\{os.path.sep}(@eaDir|node_modules|\.git|System Volume Information)(\{os.path.sep}.+)?$")
+
+
+def _touch(path: Path):
+  path.parent.mkdir(parents=True, exist_ok=True)
+  path.touch()
+
+
+def _walked_names(tmp_path: Path, skip_hidden: bool = True):
+  return sorted(entry.name for entry in fs.walk(str(tmp_path), EXCLUDE_DIR_RE, IMAGE_RE, skip_hidden))
+
+
+def test_walk_skips_dot_files_by_default(tmp_path: Path):
+  _touch(tmp_path / "photo.jpg")
+  _touch(tmp_path / ".DS_Store")
+  _touch(tmp_path / "._photo.jpg")  # AppleDouble sidecar, same extension as a real image
+
+  assert _walked_names(tmp_path) == ["photo.jpg"]
+
+
+def test_walk_skips_dot_directories_by_default(tmp_path: Path):
+  _touch(tmp_path / "photo.jpg")
+  _touch(tmp_path / ".Spotlight-V100" / "hidden.jpg")
+  _touch(tmp_path / ".Trashes" / "deleted.jpg")
+
+  assert _walked_names(tmp_path) == ["photo.jpg"]
+
+
+def test_walk_skips_system_volume_information_by_default(tmp_path: Path):
+  _touch(tmp_path / "photo.jpg")
+  _touch(tmp_path / "System Volume Information" / "metadata.jpg")
+
+  assert _walked_names(tmp_path) == ["photo.jpg"]
+
+
+def test_walk_include_hidden_indexes_dot_files_and_dirs(tmp_path: Path):
+  _touch(tmp_path / "photo.jpg")
+  _touch(tmp_path / ".DS_Store")
+  _touch(tmp_path / ".hidden_dir" / "hidden.jpg")
+
+  # .DS_Store doesn't match the image regex regardless, but the sidecar-like hidden dir now gets walked
+  assert _walked_names(tmp_path, skip_hidden=False) == ["hidden.jpg", "photo.jpg"]


### PR DESCRIPTION
Fixes #303.

Skip dot-prefixed hidden files and directories (e.g. .DS_Store, ._IMG_1234.JPG, .Spotlight-V100) by default during indexing, and exclude "System Volume Information" as a default system directory.
