### PR TITLE
fix: include dependency extras in compliance checks

### DIFF
--- a/rclip/_compliance/policy.py
+++ b/rclip/_compliance/policy.py
@@ -189,7 +189,9 @@ def _locked_runtime_versions(path: Path) -> dict[str, set[str]]:
       optional_dependencies = package.get("optional-dependencies", {})
       if not isinstance(optional_dependencies, dict):
         raise ComplianceError(f"lock file {path} has invalid optional dependencies for {name}")
-      dependencies = package.get("dependencies", []) if extra is None else optional_dependencies.get(extra, [])
+      if extra is not None and extra not in optional_dependencies:
+        raise ComplianceError(f"lock file {path} is missing selected extra {extra} for {name}")
+      dependencies = package.get("dependencies", []) if extra is None else optional_dependencies[extra]
       if not isinstance(dependencies, list):
         raise ComplianceError(f"lock file {path} has invalid dependencies for {name}")
       for dependency in dependencies:

--- a/rclip/_compliance/policy.py
+++ b/rclip/_compliance/policy.py
@@ -174,24 +174,34 @@ def _locked_runtime_versions(path: Path) -> dict[str, set[str]]:
     raise ComplianceError(f"lock file {path} has no rclip package")
 
   versions: dict[str, set[str]] = {}
-  pending = ["rclip"]
+  pending: list[tuple[str, str | None]] = [("rclip", None)]
+  seen: set[tuple[str, str | None]] = set()
   while pending:
-    name = pending.pop()
-    if name in versions:
+    name, extra = pending.pop()
+    if (name, extra) in seen:
       continue
+    seen.add((name, extra))
     locked = packages_by_name.get(name)
     if locked is None:
       raise ComplianceError(f"lock file {path} is missing runtime dependency {name}")
     versions[name] = {str(package["version"]) for package in locked}
     for package in locked:
-      dependencies = package.get("dependencies", [])
+      optional_dependencies = package.get("optional-dependencies", {})
+      if not isinstance(optional_dependencies, dict):
+        raise ComplianceError(f"lock file {path} has invalid optional dependencies for {name}")
+      dependencies = package.get("dependencies", []) if extra is None else optional_dependencies.get(extra, [])
       if not isinstance(dependencies, list):
         raise ComplianceError(f"lock file {path} has invalid dependencies for {name}")
       for dependency in dependencies:
         dependency_name = dependency.get("name") if isinstance(dependency, dict) else None
         if not isinstance(dependency_name, str) or not dependency_name:
           raise ComplianceError(f"lock file {path} has an invalid dependency for {name}")
-        pending.append(normalize_python_name(dependency_name))
+        normalized_name = normalize_python_name(dependency_name)
+        pending.append((normalized_name, None))
+        extras = dependency.get("extra", [])
+        if not isinstance(extras, list) or any(not isinstance(value, str) or not value for value in extras):
+          raise ComplianceError(f"lock file {path} has invalid dependency extras for {name}")
+        pending.extend((normalized_name, value) for value in extras)
   return versions
 
 

--- a/tests/unit/test_compliance.py
+++ b/tests/unit/test_compliance.py
@@ -313,6 +313,10 @@ version = "4"
     "optional": {"4"},
   }
 
+  lock.write_text(lock.read_text(encoding="utf-8").replace("feature =", "misspelled ="), encoding="utf-8")
+  with pytest.raises(ComplianceError, match="missing selected extra feature for runtime"):
+    _locked_runtime_versions(lock)
+
 
 def test_rawpy_source_manifest_matches_allowed_runtime_version() -> None:
   with (REPO_ROOT / "compliance/sources.toml").open("rb") as stream:

--- a/tests/unit/test_compliance.py
+++ b/tests/unit/test_compliance.py
@@ -290,18 +290,28 @@ dependencies = [{ name = "runtime", extra = ["feature"] }]
 [[package]]
 name = "runtime"
 version = "2"
+dependencies = [{ name = "normal" }]
 
 [package.optional-dependencies]
 feature = [{ name = "optional" }]
 
 [[package]]
-name = "optional"
+name = "normal"
 version = "3"
+
+[[package]]
+name = "optional"
+version = "4"
 """,
     encoding="utf-8",
   )
 
-  assert _locked_runtime_versions(lock) == {"rclip": {"1"}, "runtime": {"2"}, "optional": {"3"}}
+  assert _locked_runtime_versions(lock) == {
+    "rclip": {"1"},
+    "runtime": {"2"},
+    "normal": {"3"},
+    "optional": {"4"},
+  }
 
 
 def test_rawpy_source_manifest_matches_allowed_runtime_version() -> None:

--- a/tests/unit/test_compliance.py
+++ b/tests/unit/test_compliance.py
@@ -278,6 +278,32 @@ def test_policy_covers_locked_runtime_closure_on_every_platform() -> None:
   assert set(policy["approved_python_licenses"]) == locked_versions.keys() | unversioned
 
 
+def test_locked_runtime_closure_includes_selected_extras(tmp_path: Path) -> None:
+  lock = tmp_path / "uv.lock"
+  lock.write_text(
+    """
+[[package]]
+name = "rclip"
+version = "1"
+dependencies = [{ name = "runtime", extra = ["feature"] }]
+
+[[package]]
+name = "runtime"
+version = "2"
+
+[package.optional-dependencies]
+feature = [{ name = "optional" }]
+
+[[package]]
+name = "optional"
+version = "3"
+""",
+    encoding="utf-8",
+  )
+
+  assert _locked_runtime_versions(lock) == {"rclip": {"1"}, "runtime": {"2"}, "optional": {"3"}}
+
+
 def test_rawpy_source_manifest_matches_allowed_runtime_version() -> None:
   with (REPO_ROOT / "compliance/sources.toml").open("rb") as stream:
     source = tomllib.load(stream)["rawpy"]


### PR DESCRIPTION
## How does this PR impact the user?

Release compliance checks now include dependencies activated through selected extras, so packaged runtime components cannot bypass the licence allowlist.

## Description

- [x] Traverse selected optional-dependency edges in `uv.lock`
- [x] Cover packages reached both normally and through an extra
- [x] Fail closed on malformed dependency and extras data

## Limitations

- This changes dependency-policy resolution only; it does not add a runtime dependency.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
