### PR TITLE
feat: download remote images from the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,13 @@ The UI uses Kitty's graphics protocol when available and Sixel in terminals such
 | `Esc` | Return to the grid from an opened image. |
 | `y` | Copy the selected image to the system clipboard using Kitty's `kitten clipboard`. |
 | `Y` | Copy the selected image path. |
+| `d` | Download the selected original image from an SSH host. |
 | `q` | Quit while navigating results. |
 | `Ctrl+C` or `Ctrl+Q` | Quit from anywhere, including the search input. |
 
 Image copying requires Kitty 0.27 or newer and a discoverable `kitten` executable; the rest of the UI does not invoke Kitty executables.
+
+Over SSH, `d` preserves the original file and downloads it to `~/Downloads` on the terminal host. Kitty 0.30 or newer asks for confirmation and requires a discoverable remote `kitten` executable; `kitten ssh` provides one automatically. iTerm2 3.5 or newer uses its file-transfer protocol. If terminal detection is unavailable through SSH, set `RCLIP_DOWNLOAD_PROTOCOL` to `kitty` or `iterm2`. Locally, `d` only displays the image's existing path and does not copy it.
 
 ### Similar image search (image-to-image search)
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The UI uses Kitty's graphics protocol when available and Sixel in terminals such
 
 Image copying requires Kitty 0.27 or newer and a discoverable `kitten` executable; the rest of the UI does not invoke Kitty executables.
 
-Over SSH, `d` preserves the original file and downloads it to `~/Downloads` on the terminal host. Kitty 0.30 or newer asks for confirmation and requires a discoverable remote `kitten` executable; `kitten ssh` provides one automatically. iTerm2 3.5 or newer uses its file-transfer protocol. If terminal detection is unavailable through SSH, set `RCLIP_DOWNLOAD_PROTOCOL` to `kitty` or `iterm2`. Locally, `d` only displays the image's existing path and does not copy it.
+Over SSH, `d` downloads the original file to `~/Downloads` on the terminal host. Kitty 0.30+ requires a remote `kitten` executable (`kitten ssh` provides it) and asks for confirmation; iTerm2 3.5+ is also supported. If detection fails, set `RCLIP_DOWNLOAD_PROTOCOL` to `kitty` or `iterm2`. Locally, `d` only shows the file path.
 
 ### Similar image search (image-to-image search)
 

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -13,7 +13,9 @@ from textual.worker import get_current_worker
 from textual.widgets import Input, Static
 
 from rclip.model import Model
+from rclip.tui.transfer import _is_remote_session
 from rclip.tui.transfer import copy_image_to_clipboard
+from rclip.tui.transfer import download_image
 from rclip.tui.views import DetailScreen
 from rclip.tui.views import ImageCard
 from rclip.tui.views import ResultsGrid
@@ -49,6 +51,7 @@ class RclipApp(App[None]):
     Binding("escape", "go_back", "Back", show=False),
     Binding("y", "copy_image", "Copy image", show=False),
     Binding("Y", "copy_path", "Copy path", show=False),
+    Binding("d", "download", "Download", show=False),
     Binding("q", "quit_navigation", "Quit", show=False),
     Binding("ctrl+c", "quit", "Quit", show=False, priority=True),
     Binding("ctrl+q", "quit", "Quit", show=False, priority=True),
@@ -77,7 +80,7 @@ class RclipApp(App[None]):
     yield Input(placeholder=f"Search images in {directory}…", id="search")
     yield ResultsGrid()
     yield Static(
-      "/ Search   hjkl/Arrows Move   Enter View   y Copy image   Y Copy path   q/Ctrl+C Quit",
+      "/ Search   hjkl/Arrows Move   Enter View   y Copy   Y Copy path   d Download   q/Ctrl+C Quit",
       classes="hotkeys",
       markup=False,
     )
@@ -157,6 +160,7 @@ class RclipApp(App[None]):
     if isinstance(self.focused, Input) and action in {
       "copy_image",
       "copy_path",
+      "download",
       "move_down",
       "move_left",
       "move_right",
@@ -173,11 +177,12 @@ class RclipApp(App[None]):
         return False
     if action == "focus_search":
       return not isinstance(self.focused, Input)
-    if action in {"copy_image", "copy_path"} and isinstance(self.screen, DetailScreen):
+    if action in {"copy_image", "copy_path", "download"} and isinstance(self.screen, DetailScreen):
       return True
     if action in {
       "copy_image",
       "copy_path",
+      "download",
       "move_down",
       "move_down_or_focus",
       "move_left",
@@ -289,6 +294,20 @@ class RclipApp(App[None]):
   def action_copy_image(self) -> None:
     if filepath := self._selected_filepath():
       self._copy_image(filepath)
+
+  def action_download(self) -> None:
+    if not (filepath := self._selected_filepath()):
+      return
+    if not _is_remote_session():
+      self.notify(filepath, title="Image is already local")
+      return
+    try:
+      with self.suspend():
+        download_image(filepath)
+    except Exception as error:
+      self.notify(str(error), title="Unable to download image", severity="error")
+    else:
+      self.notify("Saved to ~/Downloads", title=Path(filepath).name)
 
   def action_quit_navigation(self) -> None:
     self.exit()

--- a/rclip/tui/transfer.py
+++ b/rclip/tui/transfer.py
@@ -1,18 +1,27 @@
+import base64
 import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 import tempfile
+from typing import Literal
 
 from PIL import ImageOps
 
 from rclip.utils import helpers
+from rclip.utils.preview import iterm_sequence
 
 
 CLIPBOARD_NATIVE_EXTENSIONS = {"bmp", "gif", "jpeg", "jpg", "png", "tif", "tiff", "webp"}
+ITERM_TRANSFER_CHUNK_SIZE = 512 * 1024
 
 
 class ClipboardError(Exception):
+  pass
+
+
+class DownloadError(Exception):
   pass
 
 
@@ -50,3 +59,46 @@ def copy_image_to_clipboard(filepath: str) -> None:
     with helpers.read_image(filepath) as opened:
       ImageOps.exif_transpose(opened).save(converted, "PNG")
     _run_clipboard_kitten(converted)
+
+
+def _is_remote_session() -> bool:
+  return bool(os.getenv("SSH_CONNECTION") or os.getenv("SSH_TTY"))
+
+
+def _download_protocol() -> Literal["kitty", "iterm2"]:
+  override = os.getenv("RCLIP_DOWNLOAD_PROTOCOL")
+  if override == "kitty":
+    return "kitty"
+  if override == "iterm2":
+    return "iterm2"
+  if override:
+    raise DownloadError("RCLIP_DOWNLOAD_PROTOCOL must be `kitty` or `iterm2`")
+  if os.getenv("TERM") == "xterm-kitty" or os.getenv("KITTY_WINDOW_ID") or os.getenv("KITTY_PUBLIC_KEY"):
+    return "kitty"
+  if os.getenv("TERM_PROGRAM") == "iTerm.app" or os.getenv("LC_TERMINAL") == "iTerm2":
+    return "iterm2"
+  raise DownloadError("could not detect Kitty or iTerm2; set RCLIP_DOWNLOAD_PROTOCOL to `kitty` or `iterm2`")
+
+
+def download_image(filepath: str) -> None:
+  """Download an original image through a remote terminal session."""
+  path = Path(filepath)
+  if _download_protocol() == "kitty":
+    completed = subprocess.run(
+      [_kitten_executable(), "transfer", str(path), "Downloads/"],
+      stderr=subprocess.PIPE,
+      text=True,
+    )
+    if completed.returncode:
+      message = completed.stderr.strip() or f"kitten exited with status {completed.returncode}"
+      raise DownloadError(message)
+    return
+
+  name = base64.b64encode(path.name.encode()).decode("ascii")
+  sys.stdout.write(iterm_sequence(f"MultipartFile=name={name};size={path.stat().st_size};inline=0"))
+  with path.open("rb") as image:
+    while chunk := image.read(ITERM_TRANSFER_CHUNK_SIZE):
+      payload = base64.b64encode(chunk).decode("ascii")
+      sys.stdout.write(iterm_sequence(f"FilePart={payload}"))
+  sys.stdout.write(iterm_sequence("FileEnd"))
+  sys.stdout.flush()

--- a/rclip/tui/transfer.py
+++ b/rclip/tui/transfer.py
@@ -17,11 +17,7 @@ CLIPBOARD_NATIVE_EXTENSIONS = {"bmp", "gif", "jpeg", "jpg", "png", "tif", "tiff"
 ITERM_TRANSFER_CHUNK_SIZE = 512 * 1024
 
 
-class ClipboardError(Exception):
-  pass
-
-
-class DownloadError(Exception):
+class TransferError(Exception):
   pass
 
 
@@ -32,7 +28,7 @@ def _kitten_executable() -> str:
     executable = Path(installation_dir) / "kitten"
     if executable.is_file():
       return str(executable)
-  raise ClipboardError("could not find Kitty's `kitten` executable")
+  raise TransferError("could not find Kitty's `kitten` executable")
 
 
 def _run_clipboard_kitten(filepath: Path) -> None:
@@ -45,7 +41,7 @@ def _run_clipboard_kitten(filepath: Path) -> None:
   )
   if completed.returncode:
     message = completed.stderr.strip() or f"kitten exited with status {completed.returncode}"
-    raise ClipboardError(message)
+    raise TransferError(message)
 
 
 def copy_image_to_clipboard(filepath: str) -> None:
@@ -72,12 +68,12 @@ def _download_protocol() -> Literal["kitty", "iterm2"]:
   if override == "iterm2":
     return "iterm2"
   if override:
-    raise DownloadError("RCLIP_DOWNLOAD_PROTOCOL must be `kitty` or `iterm2`")
+    raise TransferError("RCLIP_DOWNLOAD_PROTOCOL must be `kitty` or `iterm2`")
   if os.getenv("TERM") == "xterm-kitty" or os.getenv("KITTY_WINDOW_ID") or os.getenv("KITTY_PUBLIC_KEY"):
     return "kitty"
   if os.getenv("TERM_PROGRAM") == "iTerm.app" or os.getenv("LC_TERMINAL") == "iTerm2":
     return "iterm2"
-  raise DownloadError("could not detect Kitty or iTerm2; set RCLIP_DOWNLOAD_PROTOCOL to `kitty` or `iterm2`")
+  raise TransferError("could not detect Kitty or iTerm2; set RCLIP_DOWNLOAD_PROTOCOL to `kitty` or `iterm2`")
 
 
 def download_image(filepath: str) -> None:
@@ -91,7 +87,7 @@ def download_image(filepath: str) -> None:
     )
     if completed.returncode:
       message = completed.stderr.strip() or f"kitten exited with status {completed.returncode}"
-      raise DownloadError(message)
+      raise TransferError(message)
     return
 
   name = base64.b64encode(path.name.encode()).decode("ascii")

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -119,7 +119,7 @@ class DetailScreen(Screen[None]):
     yield Static("Loading higher-resolution image…", id="detail-status", markup=False)
     yield Static(self.filepath, id="detail-path", markup=False)
     yield Static(
-      "h/l/Arrows Browse   Esc/Double-click Back   y Copy image   Y Copy path   q/Ctrl+C Quit",
+      "h/l/Arrows Browse   Esc/Double-click Back   y Copy   Y Copy path   d Download   q/Ctrl+C Quit",
       classes="hotkeys",
       markup=False,
     )

--- a/rclip/utils/preview.py
+++ b/rclip/utils/preview.py
@@ -21,6 +21,10 @@ def _get_end_sequence():
   return "\a"
 
 
+def iterm_sequence(command: str) -> str:
+  return f"{_get_start_sequence()}1337;{command}{_get_end_sequence()}"
+
+
 def _get_preview_dimensions(width_px: int, height_px: int) -> tuple[str, str]:
   if sys.stdout.isatty() and os.name != "nt":
     try:
@@ -60,7 +64,7 @@ def preview(filepath: str, img_height_px: int):
   img_str = base64.b64encode(img_bytes).decode("utf-8")
   width, height = _get_preview_dimensions(width_px, height_px)
   print(
-    f"{_get_start_sequence()}1337;"
-    f"File=inline=1;size={len(img_bytes)};preserveAspectRatio=1;"
-    f"width={width};height={height}:{img_str}{_get_end_sequence()}",
+    iterm_sequence(
+      f"File=inline=1;size={len(img_bytes)};preserveAspectRatio=1;width={width};height={height}:{img_str}"
+    ),
   )

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -1,6 +1,10 @@
 import asyncio
+import base64
+from contextlib import nullcontext
+from io import StringIO
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 from threading import Event, Lock
@@ -18,7 +22,10 @@ from rclip.tui.app import _display_directory
 from rclip.tui.media import StableTGPImage
 from rclip.tui.media import prepare_image
 from rclip.tui.transfer import ClipboardError
+from rclip.tui.transfer import DownloadError
+from rclip.tui.transfer import _download_protocol
 from rclip.tui.transfer import copy_image_to_clipboard
+from rclip.tui.transfer import download_image
 from rclip.tui.views import DetailScreen
 from rclip.tui.views import ImageCard
 from rclip.utils.helpers import init_arg_parser
@@ -280,6 +287,67 @@ def test_tui_reports_searching_and_no_results(monkeypatch: pytest.MonkeyPatch, t
   asyncio.run(run())
 
 
+def test_download_protocol_can_be_detected_or_overridden(monkeypatch: pytest.MonkeyPatch) -> None:
+  for name in (
+    "KITTY_PUBLIC_KEY",
+    "KITTY_WINDOW_ID",
+    "LC_TERMINAL",
+    "RCLIP_DOWNLOAD_PROTOCOL",
+    "TERM",
+    "TERM_PROGRAM",
+  ):
+    monkeypatch.delenv(name, raising=False)
+
+  with pytest.raises(DownloadError, match="could not detect"):
+    _download_protocol()
+
+  monkeypatch.setenv("TERM", "xterm-kitty")
+  assert _download_protocol() == "kitty"
+
+  monkeypatch.setenv("RCLIP_DOWNLOAD_PROTOCOL", "iterm2")
+  assert _download_protocol() == "iterm2"
+
+  monkeypatch.setenv("RCLIP_DOWNLOAD_PROTOCOL", "unknown")
+  with pytest.raises(DownloadError, match="must be `kitty` or `iterm2`"):
+    _download_protocol()
+
+
+def test_download_image_uses_kitty_transfer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+  source = make_image(tmp_path / "image.jpg")
+  commands: list[tuple[list[str], dict[str, object]]] = []
+
+  def run(command: list[str], **options: object) -> subprocess.CompletedProcess[str]:
+    commands.append((command, options))
+    return subprocess.CompletedProcess(command, 0, stderr="")
+
+  monkeypatch.setenv("SSH_CONNECTION", "client 1 server 2")
+  monkeypatch.setenv("RCLIP_DOWNLOAD_PROTOCOL", "kitty")
+  monkeypatch.setattr("rclip.tui.transfer._kitten_executable", lambda: "kitten")
+  monkeypatch.setattr(subprocess, "run", run)
+
+  download_image(str(source))
+
+  assert commands == [(["kitten", "transfer", str(source), "Downloads/"], {"stderr": subprocess.PIPE, "text": True})]
+
+
+def test_download_image_streams_the_original_to_iterm2(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+  source = make_image(tmp_path / "image with spaces.jpg")
+  output = StringIO()
+  monkeypatch.setenv("SSH_TTY", "/dev/pts/1")
+  monkeypatch.setenv("RCLIP_DOWNLOAD_PROTOCOL", "iterm2")
+  monkeypatch.setenv("TERM", "xterm-256color")
+  monkeypatch.setattr(sys, "stdout", output)
+
+  download_image(str(source))
+
+  sequences = output.getvalue()
+  encoded_name = base64.b64encode(source.name.encode()).decode("ascii")
+  assert f"1337;MultipartFile=name={encoded_name};size={source.stat().st_size};inline=0\a" in sequences
+  assert sequences.endswith("1337;FileEnd\a")
+  parts = re.findall(r"1337;FilePart=([A-Za-z0-9+/=]+)\a", sequences)
+  assert b"".join(base64.b64decode(part) for part in parts) == source.read_bytes()
+
+
 def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
   paths = [make_image(tmp_path / f"image-{index}.jpg", color) for index, color in enumerate(("red", "green"))]
   rclip = FakeRclip([RClip.SearchResult(str(path), 0.9 - index / 10) for index, path in enumerate(paths)])
@@ -289,8 +357,18 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
     top_k=25,
   )
   copied: list[str] = []
+  downloaded: list[str] = []
   exits: list[bool] = []
+  notifications: list[tuple[str, str | None]] = []
   monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+  monkeypatch.setattr(
+    app,
+    "notify",
+    lambda message, **options: notifications.append((message, options.get("title"))),
+  )
+  monkeypatch.setattr(app, "suspend", nullcontext)
+  monkeypatch.setattr("rclip.tui.app.download_image", downloaded.append)
+  monkeypatch.setenv("SSH_CONNECTION", "client 1 server 2")
   monkeypatch.setattr(app, "exit", lambda *args, **kwargs: exits.append(True))
 
   async def run() -> None:
@@ -310,6 +388,12 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
 
       await pilot.press("Y")
       assert copied == [str(paths[0])]
+      await pilot.press("d")
+      assert downloaded == [str(paths[0])]
+      monkeypatch.delenv("SSH_CONNECTION")
+      await pilot.press("d")
+      assert downloaded == [str(paths[0])]
+      assert notifications[-1] == (str(paths[0]), "Image is already local")
 
       await pilot.press("right")
       assert app.focused is cards[1]

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -21,8 +21,7 @@ from rclip.tui.app import RclipApp
 from rclip.tui.app import _display_directory
 from rclip.tui.media import StableTGPImage
 from rclip.tui.media import prepare_image
-from rclip.tui.transfer import ClipboardError
-from rclip.tui.transfer import DownloadError
+from rclip.tui.transfer import TransferError
 from rclip.tui.transfer import _download_protocol
 from rclip.tui.transfer import copy_image_to_clipboard
 from rclip.tui.transfer import download_image
@@ -206,7 +205,7 @@ def test_clipboard_kitten_failure_is_reported(monkeypatch: pytest.MonkeyPatch, t
     lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 1, stderr="permission denied"),
   )
 
-  with pytest.raises(ClipboardError, match="permission denied"):
+  with pytest.raises(TransferError, match="permission denied"):
     copy_image_to_clipboard(str(make_image(tmp_path / "image.jpg")))
 
 
@@ -298,7 +297,7 @@ def test_download_protocol_can_be_detected_or_overridden(monkeypatch: pytest.Mon
   ):
     monkeypatch.delenv(name, raising=False)
 
-  with pytest.raises(DownloadError, match="could not detect"):
+  with pytest.raises(TransferError, match="could not detect"):
     _download_protocol()
 
   monkeypatch.setenv("TERM", "xterm-kitty")
@@ -308,7 +307,7 @@ def test_download_protocol_can_be_detected_or_overridden(monkeypatch: pytest.Mon
   assert _download_protocol() == "iterm2"
 
   monkeypatch.setenv("RCLIP_DOWNLOAD_PROTOCOL", "unknown")
-  with pytest.raises(DownloadError, match="must be `kitty` or `iterm2`"):
+  with pytest.raises(TransferError, match="must be `kitty` or `iterm2`"):
     _download_protocol()
 
 
@@ -328,6 +327,15 @@ def test_download_image_uses_kitty_transfer(monkeypatch: pytest.MonkeyPatch, tmp
   download_image(str(source))
 
   assert commands == [(["kitten", "transfer", str(source), "Downloads/"], {"stderr": subprocess.PIPE, "text": True})]
+
+
+def test_download_image_reports_missing_kitten(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+  monkeypatch.setenv("RCLIP_DOWNLOAD_PROTOCOL", "kitty")
+  monkeypatch.delenv("KITTY_INSTALLATION_DIR", raising=False)
+  monkeypatch.setattr("rclip.tui.transfer.shutil.which", lambda _: None)
+
+  with pytest.raises(TransferError, match="could not find Kitty"):
+    download_image(str(make_image(tmp_path / "image.jpg")))
 
 
 def test_download_image_streams_the_original_to_iterm2(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## How does this PR impact the user?

Users connected over SSH can download the selected original image to the terminal host directly from the TUI.

## Description

- [x] Transfer originals to `~/Downloads` through Kitty
- [x] Stream originals through the iTerm2 multipart file-transfer protocol
- [x] Detect the terminal protocol with an explicit override for forwarded environments

## Limitations

- Remote downloads require Kitty 0.30 or newer or iTerm2 3.5 or newer.
- Local sessions display the existing image path instead of copying the file.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
