### PR TITLE
fix: interrupt superseded TUI searches

### DIFF
--- a/rclip/main.py
+++ b/rclip/main.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 import re
 import sys
@@ -281,41 +280,60 @@ class RClip:
     top_k: int = 10,
     positive_queries: List[str] = [],
     negative_queries: List[str] = [],
+    *,
+    cancel_event: threading.Event | None = None,
   ) -> List[SearchResult]:
-    filepaths, features = self._get_features(directory)
+    filepaths, features = self._get_features(directory, cancel_event)
 
     positive_queries = [query] + positive_queries
-    sorted_similarities = self._model.compute_similarities_to_text(features, positive_queries, negative_queries)
+    sorted_similarities = self._model.compute_similarities_to_text(
+      features, positive_queries, negative_queries, cancel_event=cancel_event
+    )
 
     # exclude images that were part of the query from the results
     exclude_files = [
       os.path.abspath(query) for query in positive_queries + negative_queries if helpers.is_file_path(query)
     ]
 
-    filtered_similarities = filter(
-      lambda similarity: (
-        not self._exclude_dir_regex.match(filepaths[similarity[1]]) and filepaths[similarity[1]] not in exclude_files
-      ),
-      sorted_similarities,
-    )
-    top_k_similarities = itertools.islice(filtered_similarities, top_k)
+    results: list[RClip.SearchResult] = []
+    for score, index in sorted_similarities:
+      if len(results) >= top_k:
+        break
+      helpers.raise_if_cancelled(cancel_event)
+      filepath = filepaths[index]
+      if self._exclude_dir_regex.match(filepath) or filepath in exclude_files:
+        continue
+      results.append(RClip.SearchResult(filepath, score))
+    return results
 
-    return [RClip.SearchResult(filepath=filepaths[th[1]], score=th[0]) for th in top_k_similarities]
+  def list_images(
+    self, directory: str, top_k: int, *, cancel_event: threading.Event | None = None
+  ) -> list[str]:
+    results: list[str] = []
+    for row in self._db.get_image_filepaths_by_dir_path(directory):
+      if len(results) >= top_k:
+        break
+      helpers.raise_if_cancelled(cancel_event)
+      filepath = row["filepath"]
+      if self._exclude_dir_regex.match(filepath):
+        continue
+      results.append(filepath)
+    return results
 
-  def list_images(self, directory: str, top_k: int) -> list[str]:
-    filepaths = (row["filepath"] for row in self._db.get_image_filepaths_by_dir_path(directory))
-    included = (filepath for filepath in filepaths if not self._exclude_dir_regex.match(filepath))
-    return list(itertools.islice(included, top_k))
-
-  def _get_features(self, directory: str) -> Tuple[List[str], model.FeatureVector]:
+  def _get_features(
+    self, directory: str, cancel_event: threading.Event | None = None
+  ) -> Tuple[List[str], model.FeatureVector]:
     filepaths: List[str] = []
     features: List[model.FeatureVector] = []
     for image in self._db.get_image_vectors_by_dir_path(directory):
+      helpers.raise_if_cancelled(cancel_event)
       filepaths.append(image["filepath"])
       features.append(np.frombuffer(image["vector"], np.float32))
     if not filepaths:
       return [], np.ndarray(shape=(0, model.Model.VECTOR_SIZE))
-    return filepaths, np.stack(features)
+    stacked_features = np.stack(features)
+    helpers.raise_if_cancelled(cancel_event)
+    return filepaths, stacked_features
 
 
 def init_rclip(

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from threading import Event
 from typing import Any, List, Optional, Tuple
 
 import numpy as np
@@ -196,18 +197,28 @@ class Model:
     return text_features + image_features
 
   def compute_similarities_to_text(
-    self, item_features: FeatureVector, positive_queries: List[str], negative_queries: List[str]
+    self,
+    item_features: FeatureVector,
+    positive_queries: List[str],
+    negative_queries: List[str],
+    *,
+    cancel_event: Event | None = None,
   ) -> List[Tuple[float, int]]:
+    helpers.raise_if_cancelled(cancel_event)
     positive_features = self.compute_features_for_queries(positive_queries)
+    helpers.raise_if_cancelled(cancel_event)
     negative_features = self.compute_features_for_queries(negative_queries)
+    helpers.raise_if_cancelled(cancel_event)
 
     features = positive_features - negative_features
 
     similarities = features @ item_features.T
+    helpers.raise_if_cancelled(cancel_event)
     sorted_similarities = sorted(
       zip(similarities, range(item_features.shape[0])),
       key=lambda similarity_with_index: similarity_with_index[0],
       reverse=True,
     )
+    helpers.raise_if_cancelled(cancel_event)
 
     return sorted_similarities

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -114,17 +114,32 @@ class RclipApp(App[None]):
 
   @work(thread=True, group="search", exclusive=True, exit_on_error=False)
   def _search(self, query: str, generation: int) -> None:
+    worker = get_current_worker()
     try:
       if query and not Model.is_text_query(query):
         raise ValueError("interactive mode supports text queries only")
       with self._search_lock:
+        if worker.is_cancelled:
+          return
         if query:
-          search_results = self.rclip.search(query, self.working_directory, self.top_k)
+          search_results = self.rclip.search(
+            query,
+            self.working_directory,
+            self.top_k,
+            cancel_event=worker.cancelled_event,
+          )
           results = [TuiResult(result.filepath, result.score) for result in search_results]
         else:
           results = [
-            TuiResult(filepath) for filepath in self.rclip.list_images(self.working_directory, self.top_k)
+            TuiResult(filepath)
+            for filepath in self.rclip.list_images(
+              self.working_directory, self.top_k, cancel_event=worker.cancelled_event
+            )
           ]
+        if worker.is_cancelled:
+          return
+    except InterruptedError:
+      return
     except Exception as error:
       self.call_from_thread(self._show_search_error, generation, query, str(error))
     else:

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -5,6 +5,7 @@ import io
 import os
 import pathlib
 import textwrap
+import threading
 import warnings
 from typing import Optional, Union, cast
 from PIL import Image, UnidentifiedImageError
@@ -40,6 +41,11 @@ MaxImagePixels = Union[str, int, None]
 
 _image_loading_configured = False
 _max_image_pixels: Optional[int] = MIN_MAX_IMAGE_PIXELS
+
+
+def raise_if_cancelled(event: threading.Event | None) -> None:
+  if event is not None and event.is_set():
+    raise InterruptedError
 
 
 class ImageTooLargeError(Exception):

--- a/tests/unit/test_index_images.py
+++ b/tests/unit/test_index_images.py
@@ -1,10 +1,12 @@
 from pathlib import Path
+from threading import Event
 from unittest.mock import Mock
 import tempfile
 
 import numpy as np
 import PIL
 from PIL import Image
+import pytest
 
 from rclip.db import DB, NewImage
 from rclip.main import ImageMeta, RClip
@@ -25,6 +27,24 @@ def _too_large_on_b(path: str) -> Image.Image:
   if path == "b.jpg":
     raise helpers.ImageTooLargeError(path, 200_000_000, 100_000_000)
   return Image.new("RGB", (1, 1))
+
+
+def test_search_stops_loading_vectors_when_cancelled() -> None:
+  cancel_event = Event()
+  database = Mock()
+
+  def rows(_directory: str):
+    yield {"filepath": "a.jpg", "vector": np.zeros(512, dtype=np.float32).tobytes()}
+    cancel_event.set()
+    yield {"filepath": "b.jpg", "vector": np.zeros(512, dtype=np.float32).tobytes()}
+
+  database.get_image_vectors_by_dir_path.side_effect = rows
+  model = Mock()
+  rclip = _make_rclip(model, database)
+
+  with pytest.raises(InterruptedError):
+    rclip.search("cat", ".", cancel_event=cancel_event)
+  model.compute_similarities_to_text.assert_not_called()
 
 
 def test_load_images_preserves_order_and_skips_failures(monkeypatch):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import sys
 import tempfile
+from threading import Event
 import types
 from typing import Callable, cast
 
@@ -48,6 +49,25 @@ class FakeInferenceSession:
 
   def get_inputs(self) -> list[object]:
     return [types.SimpleNamespace(type="tensor(float)")]
+
+
+def test_similarity_stops_between_query_groups_when_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+  model = Model()
+  cancel_event = Event()
+  calls: list[list[str]] = []
+
+  def compute(queries: list[str]) -> np.ndarray:
+    calls.append(queries)
+    cancel_event.set()
+    return np.zeros(2, dtype=np.float32)
+
+  monkeypatch.setattr(model, "compute_features_for_queries", compute)
+
+  with pytest.raises(InterruptedError):
+    model.compute_similarities_to_text(
+      np.zeros((1, 2), dtype=np.float32), ["cat"], ["dog"], cancel_event=cancel_event
+    )
+  assert calls == [["cat"]]
 
 
 def test_download_coreml_model_materializes_real_package(monkeypatch: pytest.MonkeyPatch):

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -43,11 +43,13 @@ class FakeRclip(RClip):
     top_k: int = 10,
     positive_queries: list[str] = [],
     negative_queries: list[str] = [],
+    *,
+    cancel_event: Event | None = None,
   ) -> list[RClip.SearchResult]:
     self.searches.append((query, directory, top_k, positive_queries, negative_queries))
     return self.results[:top_k]
 
-  def list_images(self, directory: str, top_k: int) -> list[str]:
+  def list_images(self, directory: str, top_k: int, *, cancel_event: Event | None = None) -> list[str]:
     self.browses.append((directory, top_k))
     return [result.filepath for result in self.results[:top_k]]
 
@@ -266,7 +268,8 @@ def test_tui_reports_searching_and_no_results(monkeypatch: pytest.MonkeyPatch, t
   release = Event()
   rclip = FakeRclip([])
 
-  def list_images(_directory: str, _top_k: int) -> list[str]:
+  def list_images(_directory: str, _top_k: int, *, cancel_event: Event | None = None) -> list[str]:
+    assert cancel_event is not None
     started.set()
     assert release.wait(2)
     return []
@@ -436,6 +439,69 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
       assert app.query_one(Input).value == "q"
       await pilot.press("ctrl+c")
       assert exits == [True]
+
+  asyncio.run(run())
+
+
+def test_new_search_interrupts_the_running_search_and_keeps_one_active(tmp_path: Path) -> None:
+  class SlowRclip(FakeRclip):
+    def __init__(self) -> None:
+      super().__init__([])
+      self.active = 0
+      self.max_active = 0
+      self.first_started = Event()
+      self.second_started = Event()
+      self.first_cancelled = Event()
+      self.state_lock = Lock()
+
+    def search(
+      self,
+      query: str,
+      directory: str,
+      top_k: int = 10,
+      positive_queries: list[str] = [],
+      negative_queries: list[str] = [],
+      *,
+      cancel_event: Event | None = None,
+    ) -> list[RClip.SearchResult]:
+      assert cancel_event is not None
+      with self.state_lock:
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+      try:
+        if query == "first":
+          self.first_started.set()
+          if cancel_event.wait(2):
+            self.first_cancelled.set()
+            raise InterruptedError
+        else:
+          self.second_started.set()
+        return []
+      finally:
+        with self.state_lock:
+          self.active -= 1
+
+  rclip = SlowRclip()
+  app = RclipApp(rclip, str(tmp_path))
+
+  async def run() -> None:
+    async with app.run_test() as pilot:
+      await app.workers.wait_for_complete()
+
+      await pilot.press("f", "i", "r", "s", "t")
+      await pilot.pause(0.3)
+      assert await asyncio.to_thread(rclip.first_started.wait, 1)
+      assert app.query_one(Input).border_title == "Searching…"
+
+      await pilot.press("s")
+      await pilot.pause(0.3)
+      assert await asyncio.to_thread(rclip.second_started.wait, 1)
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+
+      assert rclip.first_cancelled.is_set()
+      assert rclip.max_active == 1
+      assert app.query_one(Input).border_title == "No results"
 
   asyncio.run(run())
 


### PR DESCRIPTION
## How does this PR impact the user?

When an interactive query is superseded, rclip stops the obsolete search at the next safe checkpoint and starts the latest query without waiting for the entire old pipeline.

## Description

- [x] Propagate Textual worker cancellation through search and similarity computation
- [x] Stop vector loading, query-group processing, and result collection when superseded
- [x] Keep one search active and prevent stale results from replacing the latest query

## Limitations

- An in-progress SQLite operation, model inference, matrix multiplication, or sort completes before the next cancellation checkpoint.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
