### PR TITLE
feat: paginate TUI results on scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Open the interactive UI and enter a query in its search input:
 rclip --interactive
 ```
 
-The UI uses Kitty's graphics protocol when available and Sixel in terminals such as iTerm2, with a colored half-cell fallback elsewhere. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images in pages. Each browse page and search returns up to 100 results by default; pass `--top N` to use a smaller limit. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and opening a result loads a higher-resolution display image.
+The UI uses Kitty's graphics protocol when available and Sixel in terminals such as iTerm2, with a colored half-cell fallback elsewhere. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches return up to 100 results by default; pass `--top N` to use a smaller search limit. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and opening a result loads a higher-resolution display image.
 
 | Key | Action |
 | --- | --- |
@@ -134,7 +134,6 @@ The UI uses Kitty's graphics protocol when available and Sixel in terminals such
 | Arrow keys or `h`, `j`, `k`, `l` | Move between results. |
 | `Enter` | Open the selected image. |
 | Left/Right or `h`/`l` | Show the previous or next opened image. |
-| `[` / `]` | Show the previous or next browse page. |
 | Double-click | Open an image, or return to the grid from an opened image. |
 | `Esc` | Return to the grid from an opened image. |
 | `y` | Copy the selected image to the system clipboard using Kitty's `kitten clipboard`. |

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Open the interactive UI and enter a query in its search input:
 rclip --interactive
 ```
 
-The UI uses Kitty's graphics protocol when available and Sixel in terminals such as iTerm2, with a colored half-cell fallback elsewhere. It uses the terminal's default colors and ANSI palette. With an empty query it browses the 100 most recently modified images by default. Pass `--top N` to use a smaller result limit. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and opening a result loads a higher-resolution display image.
+The UI uses Kitty's graphics protocol when available and Sixel in terminals such as iTerm2, with a colored half-cell fallback elsewhere. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images in pages. Each browse page and search returns up to 100 results by default; pass `--top N` to use a smaller limit. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and opening a result loads a higher-resolution display image.
 
 | Key | Action |
 | --- | --- |
@@ -134,6 +134,7 @@ The UI uses Kitty's graphics protocol when available and Sixel in terminals such
 | Arrow keys or `h`, `j`, `k`, `l` | Move between results. |
 | `Enter` | Open the selected image. |
 | Left/Right or `h`/`l` | Show the previous or next opened image. |
+| `[` / `]` | Show the previous or next browse page. |
 | Double-click | Open an image, or return to the grid from an opened image. |
 | `Esc` | Return to the grid from an opened image. |
 | `y` | Copy the selected image to the system clipboard using Kitty's `kitten clipboard`. |

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Open the interactive UI and enter a query in its search input:
 rclip --interactive
 ```
 
-The UI uses Kitty's graphics protocol when available and Sixel in terminals such as iTerm2, with a colored half-cell fallback elsewhere. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches return up to 100 results by default; pass `--top N` to use a smaller search limit. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and opening a result loads a higher-resolution display image.
+The UI uses Kitty's graphics protocol when available and Sixel in terminals such as iTerm2, with a colored half-cell fallback elsewhere. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches are ranked once and loaded in batches of up to 100 results as you scroll; pass `--top N` to use a smaller search batch. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and opening a result loads a higher-resolution display image.
 
 | Key | Action |
 | --- | --- |
@@ -252,7 +252,7 @@ Run `rclip --help` (or `rclip -h`) to see this list in your terminal. The positi
 | `query` | A text query or a path/URL to an image file. Cannot be used with `--interactive`. A relative path must be prefixed with `./` (e.g. `./cat.jpg`). Any query can be prefixed with a multiplier, e.g. `2:cat` or `0.5:./cat.jpg`. |
 | `--add`, `-a`, `+` `QUERY` | A text query or a path/URL to an image file to add to the "original" query. Can be used multiple times. |
 | `--subtract`, `--sub`, `-s`, `-` `QUERY` | A text query or a path/URL to an image file to subtract from the "original" query. Can be used multiple times. |
-| `--top`, `-t` `N` | Number of top results to display. Default: `10`, or `100` with `--interactive`; interactive maximum: `100`. |
+| `--top`, `-t` `N` | Number of top results to display, or search results to load per batch with `--interactive`. Default: `10`, or `100` with `--interactive`; interactive maximum: `100`. |
 | `--interactive`, `-i` | Open the interactive terminal UI and enter text queries there. Does not accept a positional query or `--add`/`--subtract`. Mutually exclusive with `--preview` and `--filepath-only`. |
 | `--preview`, `-p` | Preview results in the terminal (supported in iTerm2, Konsole 22.04+, wezterm, Mintty, mlterm). Mutually exclusive with `--filepath-only`. |
 | `--filepath-only`, `-f` | Output only filepaths, without scores or the header. Mutually exclusive with `--preview`. |

--- a/rclip/db.py
+++ b/rclip/db.py
@@ -170,9 +170,12 @@ class DB:
       (self._get_dirpath_like_pattern(path),),
     )
 
-  def get_image_filepaths_by_dir_path(self, path: str) -> sqlite3.Cursor:
-    return self._con.execute(
-      "SELECT filepath FROM images WHERE filepath LIKE ? ESCAPE '\\' AND deleted IS NULL "
-      "ORDER BY modified_at DESC, filepath",
-      (self._get_dirpath_like_pattern(path),),
-    )
+  def get_image_filepaths_by_dir_path(
+    self, path: str, after: tuple[float, str] | None = None
+  ) -> sqlite3.Cursor:
+    query = "SELECT filepath, modified_at FROM images WHERE filepath LIKE ? ESCAPE '\\' AND deleted IS NULL"
+    parameters: list[object] = [self._get_dirpath_like_pattern(path)]
+    if after is not None:
+      query += " AND (modified_at < ? OR (modified_at = ? AND filepath > ?))"
+      parameters.extend((after[0], after[0], after[1]))
+    return self._con.execute(query + " ORDER BY modified_at DESC, filepath", parameters)

--- a/rclip/db.py
+++ b/rclip/db.py
@@ -52,6 +52,9 @@ class DB:
     """)
     # Query for images
     self._con.execute("CREATE UNIQUE INDEX IF NOT EXISTS existing_images ON images(filepath) WHERE deleted IS NULL")
+    self._con.execute(
+      "CREATE INDEX IF NOT EXISTS recent_images ON images(modified_at DESC, filepath) WHERE deleted IS NULL"
+    )
     self._con.execute("CREATE TABLE IF NOT EXISTS db_version (version INTEGER)")
     self._con.commit()
 
@@ -176,6 +179,6 @@ class DB:
     query = "SELECT filepath, modified_at FROM images WHERE filepath LIKE ? ESCAPE '\\' AND deleted IS NULL"
     parameters: list[object] = [self._get_dirpath_like_pattern(path)]
     if after is not None:
-      query += " AND (modified_at < ? OR (modified_at = ? AND filepath > ?))"
+      query += " AND modified_at <= ? AND (modified_at < ? OR filepath > ?)"
       parameters.extend((after[0], after[0], after[1]))
     return self._con.execute(query + " ORDER BY modified_at DESC, filepath", parameters)

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -68,6 +68,14 @@ class RClip:
     filepath: str
     score: float
 
+  class ImageCursor(NamedTuple):
+    modified_at: float
+    filepath: str
+
+  class ImagePage(NamedTuple):
+    filepaths: list[str]
+    next_cursor: "RClip.ImageCursor | None"
+
   def __init__(
     self,
     model_instance: model.Model,
@@ -307,18 +315,25 @@ class RClip:
     return results
 
   def list_images(
-    self, directory: str, top_k: int, *, cancel_event: threading.Event | None = None
-  ) -> list[str]:
+    self,
+    directory: str,
+    limit: int,
+    *,
+    after: ImageCursor | None = None,
+    cancel_event: threading.Event | None = None,
+  ) -> ImagePage:
     results: list[str] = []
-    for row in self._db.get_image_filepaths_by_dir_path(directory):
-      if len(results) >= top_k:
-        break
+    last_cursor: RClip.ImageCursor | None = None
+    for row in self._db.get_image_filepaths_by_dir_path(directory, after):
       helpers.raise_if_cancelled(cancel_event)
       filepath = row["filepath"]
       if self._exclude_dir_regex.match(filepath):
         continue
+      if len(results) == limit:
+        return RClip.ImagePage(results, last_cursor)
       results.append(filepath)
-    return results
+      last_cursor = RClip.ImageCursor(float(row["modified_at"]), filepath)
+    return RClip.ImagePage(results, None)
 
   def _get_features(
     self, directory: str, cancel_event: threading.Event | None = None

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -285,7 +285,7 @@ class RClip:
     self,
     query: str,
     directory: str,
-    top_k: int = 10,
+    top_k: int | None = 10,
     positive_queries: List[str] = [],
     negative_queries: List[str] = [],
     *,
@@ -305,7 +305,7 @@ class RClip:
 
     results: list[RClip.SearchResult] = []
     for score, index in sorted_similarities:
-      if len(results) >= top_k:
+      if top_k is not None and len(results) >= top_k:
         break
       helpers.raise_if_cancelled(cancel_event)
       filepath = filepaths[index]

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -68,13 +68,14 @@ class RclipApp(App[None]):
     self.theme = os.getenv("TEXTUAL_THEME", "ansi-dark")
     self.rclip = rclip
     self.working_directory = working_directory
-    self.search_limit = top_k
+    self.search_batch_size = top_k
     self._search_timer: Timer | None = None
     self._search_lock = Lock()
     self._search_generation = 0
     self._clipboard_lock = Lock()
     self._selected_index = 0
     self._next_cursor: RClip.ImageCursor | None = None
+    self._remaining_search_results: list[TuiResult] = []
     self._loading_more = False
 
   def compose(self) -> ComposeResult:
@@ -113,16 +114,31 @@ class RclipApp(App[None]):
     self._search_generation += 1
     self._loading_more = False
     self._next_cursor = None
+    self._remaining_search_results = []
     self.query_one("#search", Input).border_title = "Searching…"
     self._search(query, self._search_generation, None)
 
   def _load_more(self) -> None:
-    if (
-      self._loading_more
-      or self._next_cursor is None
-      or self.query_one("#search", Input).value.strip()
-      or isinstance(self.screen, DetailScreen)
-    ):
+    if self._loading_more or isinstance(self.screen, DetailScreen):
+      return
+    query = self.query_one("#search", Input).value.strip()
+    if query:
+      if not self._remaining_search_results:
+        return
+      results = self._remaining_search_results[: self.search_batch_size]
+      del self._remaining_search_results[: self.search_batch_size]
+      self._loading_more = True
+      self.query_one("#search", Input).border_title = "Loading…"
+      self.call_after_refresh(
+        self._show_results,
+        self._search_generation,
+        query,
+        results,
+        None,
+        True,
+      )
+      return
+    if self._next_cursor is None:
       return
     self._loading_more = True
     self.query_one("#search", Input).border_title = "Loading…"
@@ -143,7 +159,7 @@ class RclipApp(App[None]):
           search_results = self.rclip.search(
             query,
             self.working_directory,
-            self.search_limit,
+            top_k=None,
             cancel_event=worker.cancelled_event,
           )
           results = [TuiResult(result.filepath, result.score) for result in search_results]
@@ -177,11 +193,14 @@ class RclipApp(App[None]):
     if not self._is_current_search(generation, query):
       return
     grid = self.query_one(ResultsGrid)
-    cards = [ImageCard(result) for result in results]
     if not append:
       await grid.remove_children()
       if not self._is_current_search(generation, query):
         return
+      if query:
+        self._remaining_search_results = results[self.search_batch_size :]
+        results = results[: self.search_batch_size]
+    cards = [ImageCard(result) for result in results]
     if cards:
       await grid.mount(*cards)
     if not self._is_current_search(generation, query):

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -52,6 +52,8 @@ class RclipApp(App[None]):
     Binding("y", "copy_image", "Copy image", show=False),
     Binding("Y", "copy_path", "Copy path", show=False),
     Binding("d", "download", "Download", show=False),
+    Binding("[", "previous_page", "Previous page", show=False),
+    Binding("]", "next_page", "Next page", show=False),
     Binding("q", "quit_navigation", "Quit", show=False),
     Binding("ctrl+c", "quit", "Quit", show=False, priority=True),
     Binding("ctrl+q", "quit", "Quit", show=False, priority=True),
@@ -74,13 +76,16 @@ class RclipApp(App[None]):
     self._clipboard_lock = Lock()
     self._results: list[TuiResult] = []
     self._selected_index = 0
+    self._browse_cursors: list[RClip.ImageCursor | None] = [None]
+    self._browse_page = 0
+    self._next_cursor: RClip.ImageCursor | None = None
 
   def compose(self) -> ComposeResult:
     directory = _display_directory(self.working_directory)
     yield Input(placeholder=f"Search images in {directory}…", id="search")
     yield ResultsGrid()
     yield Static(
-      "/ Search   hjkl/Arrows Move   Enter View   y Copy   Y Copy path   d Download   q/Ctrl+C Quit",
+      "/ Search   hjkl/Arrows Move   [] Page   Enter View   y Copy   Y Copy path   d Download   q/Ctrl+C Quit",
       classes="hotkeys",
       markup=False,
     )
@@ -107,14 +112,19 @@ class RclipApp(App[None]):
       self._search_timer = None
     self._begin_search(query)
 
-  def _begin_search(self, query: str) -> None:
+  def _begin_search(
+    self, query: str, after: RClip.ImageCursor | None = None, browse_page: int = 0
+  ) -> None:
     self._search_generation += 1
     self.query_one("#search", Input).border_title = "Searching…"
-    self._search(query, self._search_generation)
+    self._search(query, self._search_generation, after, browse_page)
 
   @work(thread=True, group="search", exclusive=True, exit_on_error=False)
-  def _search(self, query: str, generation: int) -> None:
+  def _search(
+    self, query: str, generation: int, after: RClip.ImageCursor | None, browse_page: int
+  ) -> None:
     worker = get_current_worker()
+    next_cursor = None
     try:
       if query and not Model.is_text_query(query):
         raise ValueError("interactive mode supports text queries only")
@@ -130,12 +140,14 @@ class RclipApp(App[None]):
           )
           results = [TuiResult(result.filepath, result.score) for result in search_results]
         else:
-          results = [
-            TuiResult(filepath)
-            for filepath in self.rclip.list_images(
-              self.working_directory, self.top_k, cancel_event=worker.cancelled_event
-            )
-          ]
+          page = self.rclip.list_images(
+            self.working_directory,
+            self.top_k,
+            after=after,
+            cancel_event=worker.cancelled_event,
+          )
+          results = [TuiResult(filepath) for filepath in page.filepaths]
+          next_cursor = page.next_cursor
         if worker.is_cancelled:
           return
     except InterruptedError:
@@ -143,17 +155,36 @@ class RclipApp(App[None]):
     except Exception as error:
       self.call_from_thread(self._show_search_error, generation, query, str(error))
     else:
-      self.call_from_thread(self._show_results, generation, query, results)
+      self.call_from_thread(
+        self._show_results, generation, query, results, next_cursor, after, browse_page
+      )
 
-  async def _show_results(self, generation: int, query: str, results: list[TuiResult]) -> None:
+  async def _show_results(
+    self,
+    generation: int,
+    query: str,
+    results: list[TuiResult],
+    next_cursor: RClip.ImageCursor | None,
+    after: RClip.ImageCursor | None,
+    browse_page: int,
+  ) -> None:
     search_input = self.query_one("#search", Input)
     if generation != self._search_generation or search_input.value.strip() != query:
       return
+    focus_results = isinstance(self.focused, ImageCard)
     grid = self.query_one(ResultsGrid)
     await grid.remove_children()
     if generation != self._search_generation:
       return
     self._results = results
+    if query:
+      self._browse_cursors = [None]
+      self._browse_page = 0
+      self._next_cursor = None
+    else:
+      self._browse_cursors[browse_page:] = [after]
+      self._browse_page = browse_page
+      self._next_cursor = next_cursor
     cards = [ImageCard(result) for result in results]
     if cards:
       await grid.mount(*cards)
@@ -162,6 +193,8 @@ class RclipApp(App[None]):
     grid.scroll_home(animate=False)
     self._selected_index = 0
     self.call_after_refresh(grid.load_visible_previews)
+    if focus_results and cards:
+      self.call_after_refresh(cards[0].focus)
     search_input.border_title = None if results else "No results"
 
   def _show_search_error(self, generation: int, query: str, message: str) -> None:
@@ -181,32 +214,29 @@ class RclipApp(App[None]):
       "move_right",
       "move_up",
       "move_up_or_focus",
+      "next_page",
+      "previous_page",
       "quit_navigation",
       "view",
     }:
       return False
-    if isinstance(self.screen, DetailScreen):
-      if action in {"move_left", "move_right"}:
-        return len(self._results) > 1
-      if action in {"focus_search", "move_down", "move_down_or_focus", "move_up", "move_up_or_focus", "view"}:
-        return False
-    if action == "focus_search":
-      return not isinstance(self.focused, Input)
-    if action in {"copy_image", "copy_path", "download"} and isinstance(self.screen, DetailScreen):
-      return True
-    if action in {
-      "copy_image",
-      "copy_path",
-      "download",
+    if isinstance(self.screen, DetailScreen) and action in {
+      "focus_search",
       "move_down",
       "move_down_or_focus",
-      "move_left",
-      "move_right",
       "move_up",
       "move_up_or_focus",
+      "next_page",
+      "previous_page",
       "view",
     }:
-      return bool(self.query(ImageCard))
+      return False
+    if action == "focus_search":
+      return not isinstance(self.focused, Input)
+    if action == "previous_page":
+      return not self.query_one("#search", Input).value.strip() and self._browse_page > 0
+    if action == "next_page":
+      return not self.query_one("#search", Input).value.strip() and self._next_cursor is not None
     return super().check_action(action, parameters)
 
   def select_card(self, card: ImageCard) -> None:
@@ -323,6 +353,17 @@ class RclipApp(App[None]):
       self.notify(str(error), title="Unable to download image", severity="error")
     else:
       self.notify("Saved to ~/Downloads", title=Path(filepath).name)
+
+  def action_previous_page(self) -> None:
+    if self._browse_page == 0:
+      return
+    page = self._browse_page - 1
+    self._begin_search("", self._browse_cursors[page], page)
+
+  def action_next_page(self) -> None:
+    if self._next_cursor is None:
+      return
+    self._begin_search("", self._next_cursor, self._browse_page + 1)
 
   def action_quit_navigation(self) -> None:
     self.exit()

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from threading import Lock
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Sequence
 
 from textual import work
 from textual.app import App, ComposeResult
@@ -37,6 +37,7 @@ def _display_directory(directory: str) -> str:
 class RclipApp(App[None]):
   TITLE = "rclip"
   CSS_PATH = "app.tcss"
+  BROWSE_BATCH_SIZE = 25
 
   BINDINGS: ClassVar[list[Binding]] = [
     Binding("/", "focus_search", "Search", show=False),
@@ -52,8 +53,6 @@ class RclipApp(App[None]):
     Binding("y", "copy_image", "Copy image", show=False),
     Binding("Y", "copy_path", "Copy path", show=False),
     Binding("d", "download", "Download", show=False),
-    Binding("[", "previous_page", "Previous page", show=False),
-    Binding("]", "next_page", "Next page", show=False),
     Binding("q", "quit_navigation", "Quit", show=False),
     Binding("ctrl+c", "quit", "Quit", show=False, priority=True),
     Binding("ctrl+q", "quit", "Quit", show=False, priority=True),
@@ -69,23 +68,21 @@ class RclipApp(App[None]):
     self.theme = os.getenv("TEXTUAL_THEME", "ansi-dark")
     self.rclip = rclip
     self.working_directory = working_directory
-    self.top_k = top_k
+    self.search_limit = top_k
     self._search_timer: Timer | None = None
     self._search_lock = Lock()
     self._search_generation = 0
     self._clipboard_lock = Lock()
-    self._results: list[TuiResult] = []
     self._selected_index = 0
-    self._browse_cursors: list[RClip.ImageCursor | None] = [None]
-    self._browse_page = 0
     self._next_cursor: RClip.ImageCursor | None = None
+    self._loading_more = False
 
   def compose(self) -> ComposeResult:
     directory = _display_directory(self.working_directory)
     yield Input(placeholder=f"Search images in {directory}…", id="search")
-    yield ResultsGrid()
+    yield ResultsGrid(self._load_more)
     yield Static(
-      "/ Search   hjkl/Arrows Move   [] Page   Enter View   y Copy   Y Copy path   d Download   q/Ctrl+C Quit",
+      "/ Search   hjkl/Arrows Move   Enter View   y Copy   Y Copy path   d Download   q/Ctrl+C Quit",
       classes="hotkeys",
       markup=False,
     )
@@ -112,18 +109,29 @@ class RclipApp(App[None]):
       self._search_timer = None
     self._begin_search(query)
 
-  def _begin_search(
-    self, query: str, after: RClip.ImageCursor | None = None, browse_page: int = 0
-  ) -> None:
+  def _begin_search(self, query: str) -> None:
     self._search_generation += 1
+    self._loading_more = False
+    self._next_cursor = None
     self.query_one("#search", Input).border_title = "Searching…"
-    self._search(query, self._search_generation, after, browse_page)
+    self._search(query, self._search_generation, None)
+
+  def _load_more(self) -> None:
+    if (
+      self._loading_more
+      or self._next_cursor is None
+      or self.query_one("#search", Input).value.strip()
+      or isinstance(self.screen, DetailScreen)
+    ):
+      return
+    self._loading_more = True
+    self.query_one("#search", Input).border_title = "Loading…"
+    self._search("", self._search_generation, self._next_cursor)
 
   @work(thread=True, group="search", exclusive=True, exit_on_error=False)
-  def _search(
-    self, query: str, generation: int, after: RClip.ImageCursor | None, browse_page: int
-  ) -> None:
+  def _search(self, query: str, generation: int, after: RClip.ImageCursor | None) -> None:
     worker = get_current_worker()
+    append = after is not None
     next_cursor = None
     try:
       if query and not Model.is_text_query(query):
@@ -135,14 +143,14 @@ class RclipApp(App[None]):
           search_results = self.rclip.search(
             query,
             self.working_directory,
-            self.top_k,
+            self.search_limit,
             cancel_event=worker.cancelled_event,
           )
           results = [TuiResult(result.filepath, result.score) for result in search_results]
         else:
           page = self.rclip.list_images(
             self.working_directory,
-            self.top_k,
+            self.BROWSE_BATCH_SIZE,
             after=after,
             cancel_event=worker.cancelled_event,
           )
@@ -153,11 +161,9 @@ class RclipApp(App[None]):
     except InterruptedError:
       return
     except Exception as error:
-      self.call_from_thread(self._show_search_error, generation, query, str(error))
+      self.call_from_thread(self._show_search_error, generation, query, str(error), append)
     else:
-      self.call_from_thread(
-        self._show_results, generation, query, results, next_cursor, after, browse_page
-      )
+      self.call_from_thread(self._show_results, generation, query, results, next_cursor, append)
 
   async def _show_results(
     self,
@@ -165,44 +171,39 @@ class RclipApp(App[None]):
     query: str,
     results: list[TuiResult],
     next_cursor: RClip.ImageCursor | None,
-    after: RClip.ImageCursor | None,
-    browse_page: int,
+    append: bool,
   ) -> None:
     search_input = self.query_one("#search", Input)
-    if generation != self._search_generation or search_input.value.strip() != query:
+    if not self._is_current_search(generation, query):
       return
-    focus_results = isinstance(self.focused, ImageCard)
     grid = self.query_one(ResultsGrid)
-    await grid.remove_children()
-    if generation != self._search_generation:
-      return
-    self._results = results
-    if query:
-      self._browse_cursors = [None]
-      self._browse_page = 0
-      self._next_cursor = None
-    else:
-      self._browse_cursors[browse_page:] = [after]
-      self._browse_page = browse_page
-      self._next_cursor = next_cursor
     cards = [ImageCard(result) for result in results]
+    if not append:
+      await grid.remove_children()
+      if not self._is_current_search(generation, query):
+        return
     if cards:
       await grid.mount(*cards)
-    if generation != self._search_generation:
+    if not self._is_current_search(generation, query):
       return
-    grid.scroll_home(animate=False)
-    self._selected_index = 0
-    self.call_after_refresh(grid.load_visible_previews)
-    if focus_results and cards:
-      self.call_after_refresh(cards[0].focus)
-    search_input.border_title = None if results else "No results"
+    self._next_cursor = next_cursor
+    self._loading_more = False
+    if not append:
+      grid.scroll_home(animate=False)
+      self._selected_index = 0
+    self.call_after_refresh(grid.update_visible)
+    search_input.border_title = None if append or results else "No results"
 
-  def _show_search_error(self, generation: int, query: str, message: str) -> None:
+  def _show_search_error(self, generation: int, query: str, message: str, append: bool) -> None:
     search_input = self.query_one("#search", Input)
-    if generation != self._search_generation or search_input.value.strip() != query:
+    if not self._is_current_search(generation, query):
       return
+    self._loading_more = False
     search_input.border_title = None
-    self.notify(message, title="Search failed", severity="error")
+    self.notify(message, title="Unable to load more images" if append else "Search failed", severity="error")
+
+  def _is_current_search(self, generation: int, query: str) -> bool:
+    return generation == self._search_generation and self.query_one("#search", Input).value.strip() == query
 
   def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
     if isinstance(self.focused, Input) and action in {
@@ -214,8 +215,6 @@ class RclipApp(App[None]):
       "move_right",
       "move_up",
       "move_up_or_focus",
-      "next_page",
-      "previous_page",
       "quit_navigation",
       "view",
     }:
@@ -226,29 +225,26 @@ class RclipApp(App[None]):
       "move_down_or_focus",
       "move_up",
       "move_up_or_focus",
-      "next_page",
-      "previous_page",
       "view",
     }:
       return False
     if action == "focus_search":
       return not isinstance(self.focused, Input)
-    if action == "previous_page":
-      return not self.query_one("#search", Input).value.strip() and self._browse_page > 0
-    if action == "next_page":
-      return not self.query_one("#search", Input).value.strip() and self._next_cursor is not None
     return super().check_action(action, parameters)
 
   def select_card(self, card: ImageCard) -> None:
-    cards = list(self.query(ImageCard))
+    cards = self._cards()
     if card in cards:
       self._selected_index = cards.index(card)
-      self.call_after_refresh(self.query_one(ResultsGrid).load_visible_previews)
+      self.call_after_refresh(self.query_one(ResultsGrid).update_visible)
+
+  def _cards(self) -> Sequence[ImageCard]:
+    return self.query_one(ResultsGrid).cards
 
   def _selected_card(self) -> ImageCard | None:
     if isinstance(self.focused, ImageCard):
       return self.focused
-    cards = list(self.query(ImageCard))
+    cards = self._cards()
     return cards[self._selected_index] if self._selected_index < len(cards) else None
 
   def _selected_filepath(self) -> str | None:
@@ -258,26 +254,33 @@ class RclipApp(App[None]):
     return card.result.filepath if card else None
 
   def _move(self, offset: int) -> None:
-    if not self._results:
+    cards = self._cards()
+    if not cards:
       return
-    index = min(max(self._selected_index + offset, 0), len(self._results) - 1)
+    index = min(max(self._selected_index + offset, 0), len(cards) - 1)
     self._selected_index = index
-    list(self.query(ImageCard))[index].focus()
+    cards[index].focus()
 
   def _columns(self) -> int:
-    cards = list(self.query(ImageCard))
+    cards = self._cards()
     if not cards:
       return 1
     first_row = cards[0].virtual_region.y
-    return max(1, sum(card.virtual_region.y == first_row for card in cards))
+    for index in range(1, len(cards)):
+      if cards[index].virtual_region.y != first_row:
+        return index
+    return len(cards)
 
   def _move_detail(self, offset: int) -> None:
-    index = min(max(self._selected_index + offset, 0), len(self._results) - 1)
+    cards = self._cards()
+    if not cards:
+      return
+    index = min(max(self._selected_index + offset, 0), len(cards) - 1)
     if index == self._selected_index:
       return
     self._selected_index = index
     if isinstance(self.screen, DetailScreen):
-      self.screen.show_image(self._results[index].filepath)
+      self.screen.show_image(cards[index].result.filepath)
 
   def action_move_left(self) -> None:
     if isinstance(self.screen, DetailScreen):
@@ -321,7 +324,7 @@ class RclipApp(App[None]):
     if isinstance(self.screen, DetailScreen):
       selected_index = self._selected_index
       self.pop_screen()
-      cards = list(self.query(ImageCard))
+      cards = self._cards()
       if selected_index < len(cards):
         self.call_after_refresh(cards[selected_index].focus)
       return
@@ -353,17 +356,6 @@ class RclipApp(App[None]):
       self.notify(str(error), title="Unable to download image", severity="error")
     else:
       self.notify("Saved to ~/Downloads", title=Path(filepath).name)
-
-  def action_previous_page(self) -> None:
-    if self._browse_page == 0:
-      return
-    page = self._browse_page - 1
-    self._begin_search("", self._browse_cursors[page], page)
-
-  def action_next_page(self) -> None:
-    if self._next_cursor is None:
-      return
-    self._begin_search("", self._next_cursor, self._browse_page + 1)
 
   def action_quit_navigation(self) -> None:
     self.exit()

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -77,6 +77,7 @@ class RclipApp(App[None]):
     self._next_cursor: RClip.ImageCursor | None = None
     self._remaining_search_results: list[TuiResult] = []
     self._loading_more = False
+    self._pending_detail_advance = False
 
   def compose(self) -> ComposeResult:
     directory = _display_directory(self.working_directory)
@@ -112,6 +113,7 @@ class RclipApp(App[None]):
 
   def _begin_search(self, query: str) -> None:
     self._search_generation += 1
+    self._pending_detail_advance = False
     self._loading_more = False
     self._next_cursor = None
     self._remaining_search_results = []
@@ -119,7 +121,7 @@ class RclipApp(App[None]):
     self._search(query, self._search_generation, None)
 
   def _load_more(self) -> None:
-    if self._loading_more or isinstance(self.screen, DetailScreen):
+    if self._loading_more or (isinstance(self.screen, DetailScreen) and not self._pending_detail_advance):
       return
     query = self.query_one("#search", Input).value.strip()
     if query:
@@ -207,6 +209,10 @@ class RclipApp(App[None]):
       return
     self._next_cursor = next_cursor
     self._loading_more = False
+    if append and self._pending_detail_advance:
+      self._pending_detail_advance = False
+      if cards and isinstance(self.screen, DetailScreen):
+        self._move_detail(1)
     if not append:
       grid.scroll_home(animate=False)
       self._selected_index = 0
@@ -218,6 +224,7 @@ class RclipApp(App[None]):
     if not self._is_current_search(generation, query):
       return
     self._loading_more = False
+    self._pending_detail_advance = False
     search_input.border_title = None
     self.notify(message, title="Unable to load more images" if append else "Search failed", severity="error")
 
@@ -291,8 +298,15 @@ class RclipApp(App[None]):
     return len(cards)
 
   def _move_detail(self, offset: int) -> None:
+    self._pending_detail_advance = False
     cards = self._cards()
     if not cards:
+      return
+    if self._selected_index + offset >= len(cards) and (
+      self._loading_more or self._next_cursor or self._remaining_search_results
+    ):
+      self._pending_detail_advance = True
+      self._load_more()
       return
     index = min(max(self._selected_index + offset, 0), len(cards) - 1)
     if index == self._selected_index:
@@ -340,6 +354,7 @@ class RclipApp(App[None]):
       self.push_screen(DetailScreen(card.result.filepath))
 
   def action_go_back(self) -> None:
+    self._pending_detail_advance = False
     if isinstance(self.screen, DetailScreen):
       selected_index = self._selected_index
       self.pop_screen()

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -1,7 +1,9 @@
+from bisect import bisect_right
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
 from threading import Semaphore
+from typing import Callable, Sequence, cast
 
 from textual import events, work
 from textual.app import ComposeResult
@@ -85,26 +87,40 @@ class ImageCard(Static, can_focus=True):
 
 
 class ResultsGrid(ItemGrid):
-  def __init__(self) -> None:
+  def __init__(self, load_more: Callable[[], None]) -> None:
     super().__init__(
       id="results",
       min_column_width=24,
       regular=False,
       stretch_height=False,
     )
+    self._load_more = load_more
 
-  def load_visible_previews(self) -> None:
+  @property
+  def cards(self) -> Sequence[ImageCard]:
+    # Textual types child collections as generic widgets; this grid mounts only image cards.
+    return cast(Sequence[ImageCard], self.children)
+
+  def update_visible(self) -> None:
     viewport = self.scrollable_content_region
-    for card in self.query(ImageCard):
-      if card.region.overlaps(viewport):
-        card.load_preview()
+    cards = self.cards
+    index = bisect_right(cards, self.scroll_y, key=lambda card: card.virtual_region.bottom)
+    visible_bottom = self.scroll_y + viewport.height
+    while index < len(cards):
+      card = cards[index]
+      if card.virtual_region.y >= visible_bottom:
+        break
+      card.load_preview()
+      index += 1
+    if self.max_scroll_y - self.scroll_y <= viewport.height:
+      self._load_more()
 
   def watch_scroll_y(self, old_value: float, new_value: float) -> None:
     super().watch_scroll_y(old_value, new_value)
-    self.call_after_refresh(self.load_visible_previews)
+    self.call_after_refresh(self.update_visible)
 
   def on_resize(self, _event: events.Resize) -> None:
-    self.call_after_refresh(self.load_visible_previews)
+    self.call_after_refresh(self.update_visible)
 
 
 class DetailScreen(Screen[None]):

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -296,7 +296,7 @@ def init_arg_parser() -> argparse.ArgumentParser:
     "--top",
     "-t",
     type=positive_int_arg_type,
-    help="number of top results to display; default: 10, or 100 with --interactive; interactive maximum: 100",
+    help="number of top search results to display; default: 10, or 100 with --interactive; interactive maximum: 100",
   )
   display_mode_group = parser.add_mutually_exclusive_group()
   display_mode_group.add_argument(

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -296,7 +296,8 @@ def init_arg_parser() -> argparse.ArgumentParser:
     "--top",
     "-t",
     type=positive_int_arg_type,
-    help="number of top search results to display; default: 10, or 100 with --interactive; interactive maximum: 100",
+    help="number of top results to display, or load per search batch with --interactive;"
+    " default: 10, or 100 with --interactive; interactive maximum: 100",
   )
   display_mode_group = parser.add_mutually_exclusive_group()
   display_mode_group.add_argument(

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -88,11 +88,21 @@ def test_lists_recent_image_filepaths(tmp_path):
   try:
     photos = tmp_path / "photos"
     old = str(photos / "old.jpg")
-    new = str(photos / "new.jpg")
+    new_a = str(photos / "new-a.jpg")
+    new_b = str(photos / "new-b.jpg")
     database.upsert_image(_new_image(old, modified_at=1))
-    database.upsert_image(_new_image(new, modified_at=2))
+    database.upsert_image(_new_image(new_b, modified_at=2))
+    database.upsert_image(_new_image(new_a, modified_at=2))
     database.upsert_image(_new_image(str(tmp_path / "elsewhere" / "image.jpg"), modified_at=3))
 
-    assert [row["filepath"] for row in database.get_image_filepaths_by_dir_path(str(photos))] == [new, old]
+    assert [row["filepath"] for row in database.get_image_filepaths_by_dir_path(str(photos))] == [
+      new_a,
+      new_b,
+      old,
+    ]
+    assert [row["filepath"] for row in database.get_image_filepaths_by_dir_path(str(photos), (2, new_a))] == [
+      new_b,
+      old,
+    ]
   finally:
     database.close()

--- a/tests/unit/test_index_images.py
+++ b/tests/unit/test_index_images.py
@@ -47,6 +47,21 @@ def test_search_stops_loading_vectors_when_cancelled() -> None:
   model.compute_similarities_to_text.assert_not_called()
 
 
+def test_search_can_return_every_ranked_result() -> None:
+  database = Mock()
+  database.get_image_vectors_by_dir_path.return_value = [
+    {"filepath": f"{index}.jpg", "vector": np.zeros(512, dtype=np.float32).tobytes()}
+    for index in range(12)
+  ]
+  model = Mock()
+  model.compute_similarities_to_text.return_value = [(float(index), index) for index in range(12)]
+  rclip = _make_rclip(model, database)
+
+  assert rclip.search("cat", ".", top_k=None) == [
+    RClip.SearchResult(f"{index}.jpg", float(index)) for index in range(12)
+  ]
+
+
 def test_load_images_preserves_order_and_skips_failures(monkeypatch):
   monkeypatch.setattr(helpers, "_ensure_image_loading_configured", lambda: None)
   monkeypatch.setattr(helpers, "read_image", _fail_on_b)

--- a/tests/unit/test_index_images.py
+++ b/tests/unit/test_index_images.py
@@ -71,13 +71,18 @@ def test_load_images_preserves_order_and_skips_failures(monkeypatch):
 def test_list_images_applies_exclusions_before_the_limit(tmp_path: Path) -> None:
   database = DB(tmp_path / "db.sqlite3")
   private = tmp_path / "private" / "new.jpg"
-  included = tmp_path / "included.jpg"
-  database.upsert_image(NewImage(filepath=str(private), modified_at=2, size=1, vector=b"x", hash=None))
-  database.upsert_image(NewImage(filepath=str(included), modified_at=1, size=1, vector=b"x", hash=None))
+  first = tmp_path / "first.jpg"
+  second = tmp_path / "second.jpg"
+  database.upsert_image(NewImage(filepath=str(private), modified_at=3, size=1, vector=b"x", hash=None))
+  database.upsert_image(NewImage(filepath=str(first), modified_at=2, size=1, vector=b"x", hash=None))
+  database.upsert_image(NewImage(filepath=str(second), modified_at=1, size=1, vector=b"x", hash=None))
   rclip = _make_rclip(Mock(), database, ["private"])
 
   try:
-    assert rclip.list_images(str(tmp_path), 1) == [str(included)]
+    first_page = rclip.list_images(str(tmp_path), 1)
+    assert first_page.filepaths == [str(first)]
+    assert first_page.next_cursor == RClip.ImageCursor(2, str(first))
+    assert rclip.list_images(str(tmp_path), 1, after=first_page.next_cursor) == RClip.ImagePage([str(second)], None)
   finally:
     rclip.close()
     database.close()

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -466,6 +466,93 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
   asyncio.run(run())
 
 
+@pytest.mark.parametrize("query", ["", "cat"])
+def test_detail_navigation_loads_more_results(tmp_path: Path, query: str) -> None:
+  paths = [str(tmp_path / f"image-{index}.jpg") for index in range(51)]
+  rclip = FakeRclip([RClip.SearchResult(path, 1) for path in paths])
+  app = RclipApp(rclip, str(tmp_path), top_k=25)
+
+  async def run() -> None:
+    async with app.run_test(size=(80, 24)) as pilot:
+      await app.workers.wait_for_complete()
+      if query:
+        await pilot.press(*query, "enter")
+        await app.workers.wait_for_complete()
+      await pilot.pause()
+      assert len(app.query(ImageCard)) == 25
+      await pilot.press("down", "enter")
+      assert isinstance(app.screen, DetailScreen)
+      for index, path in enumerate(paths[1:], 1):
+        if index % 25 == 0:
+          # Repeated input before the batch arrives must still advance exactly once.
+          app.action_move_right()
+          app.action_move_right()
+        else:
+          await pilot.press("right")
+        await app.workers.wait_for_complete()
+        await pilot.pause(0.1)
+        assert app.screen.filepath == path
+      await pilot.press("right")
+      assert app.screen.filepath == paths[-1]
+      await pilot.press("left")
+      assert app.screen.filepath == paths[-2]
+      await pilot.press("escape")
+      await pilot.pause()
+      assert isinstance(app.focused, ImageCard)
+      assert app.focused.result.filepath == paths[-2]
+      assert [card.result.filepath for card in app.query(ImageCard)] == paths
+
+  asyncio.run(run())
+  assert len(rclip.browses) == (1 if query else 3)
+  assert rclip.searches == ([(query, str(tmp_path), None, [], [])] if query else [])
+
+
+@pytest.mark.parametrize("action", ["left", "escape"])
+def test_detail_navigation_cancels_pending_advance(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch, action: str
+) -> None:
+  paths = [str(tmp_path / f"image-{index}.jpg") for index in range(26)]
+  rclip = FakeRclip([RClip.SearchResult(path, 1) for path in paths])
+  list_images = rclip.list_images
+  started = Event()
+  release = Event()
+
+  def slow_list_images(
+    directory: str, limit: int, *, after: RClip.ImageCursor | None = None, cancel_event: Event | None = None
+  ) -> RClip.ImagePage:
+    if after is not None:
+      started.set()
+      assert release.wait(5)
+    return list_images(directory, limit, after=after, cancel_event=cancel_event)
+
+  monkeypatch.setattr(rclip, "list_images", slow_list_images)
+  app = RclipApp(rclip, str(tmp_path))
+
+  async def run() -> None:
+    async with app.run_test(size=(80, 24)) as pilot:
+      try:
+        await app.workers.wait_for_complete()
+        await pilot.press("down", "enter")
+        await pilot.press(*(["right"] * 25))
+        assert await asyncio.to_thread(started.wait, 1)
+        await pilot.press("right", action)
+      finally:
+        release.set()
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+      assert len(app.query(ImageCard)) == 26
+      if action == "left":
+        assert isinstance(app.screen, DetailScreen)
+        assert app.screen.filepath == paths[23]
+      else:
+        assert not isinstance(app.screen, DetailScreen)
+        assert isinstance(app.focused, ImageCard)
+        assert app.focused.result.filepath == paths[24]
+
+  asyncio.run(run())
+  assert len(rclip.browses) == 2
+
+
 def test_new_search_interrupts_the_running_search_and_keeps_one_active(tmp_path: Path) -> None:
   class SlowRclip(FakeRclip):
     def __init__(self) -> None:
@@ -694,8 +781,9 @@ def test_search_loads_more_on_scroll(tmp_path: Path) -> None:
   assert rclip.searches == [("cat", str(tmp_path), None, [], [])]
 
 
-def test_empty_browse_loads_more_on_scroll_and_retries_after_failure(
-  tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("detail", [False, True])
+def test_empty_browse_retries_loading_more_after_failure(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch, detail: bool
 ) -> None:
   paths = [tmp_path / f"image-{index}.jpg" for index in range(26)]
   rclip = FakeRclip([RClip.SearchResult(str(path), 1 - index / 10) for index, path in enumerate(paths)])
@@ -731,18 +819,29 @@ def test_empty_browse_loads_more_on_scroll_and_retries_after_failure(
       assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:25]]
 
       grid = app.query_one(ResultsGrid)
-      grid.scroll_end(animate=False)
+      if detail:
+        await pilot.press("down", "enter", *(["right"] * 25))
+      else:
+        grid.scroll_end(animate=False)
       await app.workers.wait_for_complete()
       await pilot.pause()
       assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:25]]
       assert notifications == [("page failed", "Unable to load more images")]
 
-      grid.scroll_home(animate=False)
-      await pilot.pause()
-      grid.scroll_end(animate=False)
+      if detail:
+        assert isinstance(app.screen, DetailScreen)
+        assert app.screen.filepath == str(paths[24])
+        await pilot.press("right")
+      else:
+        grid.scroll_home(animate=False)
+        await pilot.pause()
+        grid.scroll_end(animate=False)
       await app.workers.wait_for_complete()
       await pilot.pause()
       assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths]
+      if detail:
+        assert isinstance(app.screen, DetailScreen)
+        assert app.screen.filepath == str(paths[25])
 
   asyncio.run(run())
 

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -34,7 +34,7 @@ class FakeRclip(RClip):
   def __init__(self, results: list[RClip.SearchResult]) -> None:
     self.results = results
     self.searches: list[tuple[str, str, int, list[str], list[str]]] = []
-    self.browses: list[tuple[str, int]] = []
+    self.browses: list[tuple[str, int, RClip.ImageCursor | None]] = []
 
   def search(
     self,
@@ -49,9 +49,24 @@ class FakeRclip(RClip):
     self.searches.append((query, directory, top_k, positive_queries, negative_queries))
     return self.results[:top_k]
 
-  def list_images(self, directory: str, top_k: int, *, cancel_event: Event | None = None) -> list[str]:
-    self.browses.append((directory, top_k))
-    return [result.filepath for result in self.results[:top_k]]
+  def list_images(
+    self,
+    directory: str,
+    limit: int,
+    *,
+    after: RClip.ImageCursor | None = None,
+    cancel_event: Event | None = None,
+  ) -> RClip.ImagePage:
+    self.browses.append((directory, limit, after))
+    start = 0 if after is None else next(
+      index + 1 for index, result in enumerate(self.results) if result.filepath == after.filepath
+    )
+    results = self.results[start : start + limit]
+    next_cursor = None
+    if start + limit < len(self.results):
+      last_index = start + len(results) - 1
+      next_cursor = RClip.ImageCursor(float(len(self.results) - last_index), results[-1].filepath)
+    return RClip.ImagePage([result.filepath for result in results], next_cursor)
 
 
 def make_image(path: Path, color: str = "red") -> Path:
@@ -268,11 +283,18 @@ def test_tui_reports_searching_and_no_results(monkeypatch: pytest.MonkeyPatch, t
   release = Event()
   rclip = FakeRclip([])
 
-  def list_images(_directory: str, _top_k: int, *, cancel_event: Event | None = None) -> list[str]:
+  def list_images(
+    _directory: str,
+    _top_k: int,
+    *,
+    after: RClip.ImageCursor | None = None,
+    cancel_event: Event | None = None,
+  ) -> RClip.ImagePage:
+    assert after is None
     assert cancel_event is not None
     started.set()
     assert release.wait(2)
-    return []
+    return RClip.ImagePage([], None)
 
   monkeypatch.setattr(rclip, "list_images", list_images)
   app = RclipApp(rclip, str(tmp_path))
@@ -559,6 +581,69 @@ def test_interactive_top_limits_empty_browse(tmp_path: Path) -> None:
       await pilot.pause()
 
       assert len(app.query(ImageCard)) == 25
-      assert rclip.browses == [(str(tmp_path), 25)]
+      assert rclip.browses == [(str(tmp_path), 25, None)]
 
   asyncio.run(run())
+
+
+def test_empty_browse_replaces_pages_and_returns_to_the_previous_page(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  paths = [make_image(tmp_path / f"image-{index}.jpg") for index in range(3)]
+  rclip = FakeRclip([RClip.SearchResult(str(path), 1 - index / 10) for index, path in enumerate(paths)])
+  app = RclipApp(rclip, str(tmp_path), top_k=2)
+  list_images = rclip.list_images
+  failed = False
+
+  def fail_second_page_once(
+    directory: str,
+    limit: int,
+    *,
+    after: RClip.ImageCursor | None = None,
+    cancel_event: Event | None = None,
+  ) -> RClip.ImagePage:
+    nonlocal failed
+    if after is not None and not failed:
+      failed = True
+      raise RuntimeError("page failed")
+    return list_images(directory, limit, after=after, cancel_event=cancel_event)
+
+  monkeypatch.setattr(rclip, "list_images", fail_second_page_once)
+
+  async def run() -> None:
+    async with app.run_test() as pilot:
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:2]]
+
+      await pilot.press("down")
+      assert app.check_action("previous_page", ()) is False
+      assert app.check_action("next_page", ()) is True
+      await pilot.press("]")
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:2]]
+      assert app.check_action("previous_page", ()) is False
+      assert app.check_action("next_page", ()) is True
+
+      await pilot.press("]")
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+      assert [card.result.filepath for card in app.query(ImageCard)] == [str(paths[2])]
+      assert isinstance(app.focused, ImageCard)
+      assert app.check_action("previous_page", ()) is True
+      assert app.check_action("next_page", ()) is False
+
+      await pilot.press("[")
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:2]]
+
+  asyncio.run(run())
+
+  cursor = RClip.ImageCursor(2, str(paths[1]))
+  assert rclip.browses == [
+    (str(tmp_path), 2, None),
+    (str(tmp_path), 2, cursor),
+    (str(tmp_path), 2, None),
+  ]

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -686,7 +686,7 @@ def test_search_loads_more_on_scroll(tmp_path: Path) -> None:
       assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:25]]
 
       app.query_one(ResultsGrid).scroll_end(animate=False)
-      await pilot.pause()
+      await pilot.pause(0.1)
       assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths]
 
   asyncio.run(run())

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -27,6 +27,7 @@ from rclip.tui.transfer import copy_image_to_clipboard
 from rclip.tui.transfer import download_image
 from rclip.tui.views import DetailScreen
 from rclip.tui.views import ImageCard
+from rclip.tui.views import ResultsGrid
 from rclip.utils.helpers import init_arg_parser
 
 
@@ -528,9 +529,57 @@ def test_new_search_interrupts_the_running_search_and_keeps_one_active(tmp_path:
   asyncio.run(run())
 
 
+def test_new_search_interrupts_loading_more(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+  paths = [tmp_path / f"image-{index}.jpg" for index in range(26)]
+  rclip = FakeRclip([RClip.SearchResult(str(path), 1 - index / 10) for index, path in enumerate(paths)])
+  list_images = rclip.list_images
+  page_started = Event()
+  page_cancelled = Event()
+
+  def slow_list_images(
+    directory: str,
+    limit: int,
+    *,
+    after: RClip.ImageCursor | None = None,
+    cancel_event: Event | None = None,
+  ) -> RClip.ImagePage:
+    if after is None:
+      return list_images(directory, limit, cancel_event=cancel_event)
+    assert cancel_event is not None
+    page_started.set()
+    if cancel_event.wait(2):
+      page_cancelled.set()
+      raise InterruptedError
+    raise AssertionError("loading more was not cancelled")
+
+  monkeypatch.setattr(rclip, "list_images", slow_list_images)
+  app = RclipApp(rclip, str(tmp_path), top_k=25)
+
+  async def run() -> None:
+    async with app.run_test() as pilot:
+      await app.workers.wait_for_complete()
+      app.query_one(ResultsGrid).scroll_end(animate=False)
+      await pilot.pause()
+      assert await asyncio.to_thread(page_started.wait, 1)
+
+      search_input = app.query_one(Input)
+      search_input.focus()
+      search_input.value = "cat"
+      await pilot.pause(0.3)
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+
+      assert page_cancelled.is_set()
+      assert rclip.searches == [("cat", str(tmp_path), 25, [], [])]
+      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:25]]
+
+  asyncio.run(run())
+
+
 def test_tui_only_loads_visible_previews(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
   path = make_image(tmp_path / "image.jpg")
-  rclip = FakeRclip([RClip.SearchResult(str(path), 1 - index / 100) for index in range(100)])
+  filepaths = [str(tmp_path / f"image-{index}.jpg") for index in range(100)]
+  rclip = FakeRclip([RClip.SearchResult(filepath, 1 - index / 100) for index, filepath in enumerate(filepaths)])
   app = RclipApp(rclip, str(tmp_path))
   loaded: list[str] = []
   lock = Lock()
@@ -557,7 +606,7 @@ def test_tui_only_loads_visible_previews(tmp_path: Path, monkeypatch: pytest.Mon
   monkeypatch.setattr("rclip.tui.views.prepare_image", prepare)
 
   async def run() -> None:
-    async with app.run_test(size=(80, 24)):
+    async with app.run_test(size=(80, 24)) as pilot:
       assert await asyncio.to_thread(four_started.wait, 1)
       await asyncio.sleep(0.05)
       assert max_active == 4
@@ -567,13 +616,21 @@ def test_tui_only_loads_visible_previews(tmp_path: Path, monkeypatch: pytest.Mon
 
       assert 0 < len(loaded) < len(app.query(ImageCard))
 
+      grid = app.query_one(ResultsGrid)
+      grid.scroll_end(animate=False)
+      await pilot.pause()
+      grid.update_visible()
+      await pilot.pause()
+      await app.workers.wait_for_complete()
+      assert filepaths[24] in loaded
+
   asyncio.run(run())
 
 
-def test_interactive_top_limits_empty_browse(tmp_path: Path) -> None:
-  path = make_image(tmp_path / "image.jpg")
-  rclip = FakeRclip([RClip.SearchResult(str(path), 1 - index / 50) for index in range(50)])
-  app = RclipApp(rclip, str(tmp_path), top_k=25)
+def test_empty_browse_uses_bounded_batches(tmp_path: Path) -> None:
+  results = [RClip.SearchResult(str(tmp_path / f"image-{index}.jpg"), 1 - index / 50) for index in range(50)]
+  rclip = FakeRclip(results)
+  app = RclipApp(rclip, str(tmp_path), top_k=10)
 
   async def run() -> None:
     async with app.run_test() as pilot:
@@ -586,14 +643,41 @@ def test_interactive_top_limits_empty_browse(tmp_path: Path) -> None:
   asyncio.run(run())
 
 
-def test_empty_browse_replaces_pages_and_returns_to_the_previous_page(
+def test_empty_browse_loads_more_as_keyboard_moves_down(tmp_path: Path) -> None:
+  paths = [tmp_path / f"image-{index}.jpg" for index in range(26)]
+  rclip = FakeRclip([RClip.SearchResult(str(path), 1 - index / 10) for index, path in enumerate(paths)])
+  app = RclipApp(rclip, str(tmp_path), top_k=25)
+
+  async def run() -> None:
+    async with app.run_test(size=(80, 24)) as pilot:
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+
+      for _ in range(10):
+        await pilot.press("down")
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+
+      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths]
+
+  asyncio.run(run())
+
+  cursor = RClip.ImageCursor(2, str(paths[24]))
+  assert rclip.browses == [
+    (str(tmp_path), 25, None),
+    (str(tmp_path), 25, cursor),
+  ]
+
+
+def test_empty_browse_loads_more_on_scroll_and_retries_after_failure(
   tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-  paths = [make_image(tmp_path / f"image-{index}.jpg") for index in range(3)]
+  paths = [tmp_path / f"image-{index}.jpg" for index in range(26)]
   rclip = FakeRclip([RClip.SearchResult(str(path), 1 - index / 10) for index, path in enumerate(paths)])
-  app = RclipApp(rclip, str(tmp_path), top_k=2)
+  app = RclipApp(rclip, str(tmp_path), top_k=25)
   list_images = rclip.list_images
   failed = False
+  notifications: list[tuple[str, str | None]] = []
 
   def fail_second_page_once(
     directory: str,
@@ -609,41 +693,36 @@ def test_empty_browse_replaces_pages_and_returns_to_the_previous_page(
     return list_images(directory, limit, after=after, cancel_event=cancel_event)
 
   monkeypatch.setattr(rclip, "list_images", fail_second_page_once)
+  monkeypatch.setattr(
+    app,
+    "notify",
+    lambda message, **options: notifications.append((message, options.get("title"))),
+  )
 
   async def run() -> None:
     async with app.run_test() as pilot:
       await app.workers.wait_for_complete()
       await pilot.pause()
-      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:2]]
+      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:25]]
 
-      await pilot.press("down")
-      assert app.check_action("previous_page", ()) is False
-      assert app.check_action("next_page", ()) is True
-      await pilot.press("]")
+      grid = app.query_one(ResultsGrid)
+      grid.scroll_end(animate=False)
       await app.workers.wait_for_complete()
       await pilot.pause()
-      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:2]]
-      assert app.check_action("previous_page", ()) is False
-      assert app.check_action("next_page", ()) is True
+      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:25]]
+      assert notifications == [("page failed", "Unable to load more images")]
 
-      await pilot.press("]")
+      grid.scroll_home(animate=False)
+      await pilot.pause()
+      grid.scroll_end(animate=False)
       await app.workers.wait_for_complete()
       await pilot.pause()
-      assert [card.result.filepath for card in app.query(ImageCard)] == [str(paths[2])]
-      assert isinstance(app.focused, ImageCard)
-      assert app.check_action("previous_page", ()) is True
-      assert app.check_action("next_page", ()) is False
-
-      await pilot.press("[")
-      await app.workers.wait_for_complete()
-      await pilot.pause()
-      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:2]]
+      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths]
 
   asyncio.run(run())
 
-  cursor = RClip.ImageCursor(2, str(paths[1]))
+  cursor = RClip.ImageCursor(2, str(paths[24]))
   assert rclip.browses == [
-    (str(tmp_path), 2, None),
-    (str(tmp_path), 2, cursor),
-    (str(tmp_path), 2, None),
+    (str(tmp_path), 25, None),
+    (str(tmp_path), 25, cursor),
   ]

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -34,14 +34,14 @@ from rclip.utils.helpers import init_arg_parser
 class FakeRclip(RClip):
   def __init__(self, results: list[RClip.SearchResult]) -> None:
     self.results = results
-    self.searches: list[tuple[str, str, int, list[str], list[str]]] = []
+    self.searches: list[tuple[str, str, int | None, list[str], list[str]]] = []
     self.browses: list[tuple[str, int, RClip.ImageCursor | None]] = []
 
   def search(
     self,
     query: str,
     directory: str,
-    top_k: int = 10,
+    top_k: int | None = 10,
     positive_queries: list[str] = [],
     negative_queries: list[str] = [],
     *,
@@ -132,7 +132,7 @@ def test_interactive_main_rejects_additional_queries_before_setup(option: str, m
     main_module.main()
 
 
-def test_interactive_main_rejects_more_than_100_results_before_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_interactive_main_rejects_search_batches_larger_than_100(monkeypatch: pytest.MonkeyPatch) -> None:
   monkeypatch.setattr(sys, "argv", ["rclip", "--interactive", "--top", "101"])
   monkeypatch.setattr(main_module, "init_rclip", lambda **_options: pytest.fail("must reject before setup"))
 
@@ -415,7 +415,7 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
       cards = list(app.query(ImageCard))
       assert len(cards) == 2
       assert isinstance(app.focused, Input)
-      assert rclip.searches == [("cat", str(tmp_path), 25, [], [])]
+      assert rclip.searches == [("cat", str(tmp_path), None, [], [])]
 
       await pilot.press("down")
       assert app.focused is cards[0]
@@ -481,7 +481,7 @@ def test_new_search_interrupts_the_running_search_and_keeps_one_active(tmp_path:
       self,
       query: str,
       directory: str,
-      top_k: int = 10,
+      top_k: int | None = 10,
       positive_queries: list[str] = [],
       negative_queries: list[str] = [],
       *,
@@ -570,7 +570,7 @@ def test_new_search_interrupts_loading_more(tmp_path: Path, monkeypatch: pytest.
       await pilot.pause()
 
       assert page_cancelled.is_set()
-      assert rclip.searches == [("cat", str(tmp_path), 25, [], [])]
+      assert rclip.searches == [("cat", str(tmp_path), None, [], [])]
       assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:25]]
 
   asyncio.run(run())
@@ -667,6 +667,31 @@ def test_empty_browse_loads_more_as_keyboard_moves_down(tmp_path: Path) -> None:
     (str(tmp_path), 25, None),
     (str(tmp_path), 25, cursor),
   ]
+
+
+def test_search_loads_more_on_scroll(tmp_path: Path) -> None:
+  paths = [tmp_path / f"image-{index}.jpg" for index in range(26)]
+  rclip = FakeRclip([RClip.SearchResult(str(path), 1 - index / 10) for index, path in enumerate(paths)])
+  app = RclipApp(rclip, str(tmp_path), top_k=25)
+
+  async def run() -> None:
+    async with app.run_test(size=(80, 24)) as pilot:
+      await app.workers.wait_for_complete()
+
+      search_input = app.query_one(Input)
+      search_input.value = "cat"
+      await pilot.pause(0.3)
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:25]]
+
+      app.query_one(ResultsGrid).scroll_end(animate=False)
+      await pilot.pause()
+      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths]
+
+  asyncio.run(run())
+
+  assert rclip.searches == [("cat", str(tmp_path), None, [], [])]
 
 
 def test_empty_browse_loads_more_on_scroll_and_retries_after_failure(

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -773,7 +773,9 @@ def test_search_loads_more_on_scroll(tmp_path: Path) -> None:
       assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:25]]
 
       app.query_one(ResultsGrid).scroll_end(animate=False)
-      await pilot.pause(0.1)
+      async with asyncio.timeout(0.25):
+        while len(app.query(ImageCard)) != 26:
+          await asyncio.sleep(0.01)
       assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths]
 
   asyncio.run(run())


### PR DESCRIPTION
## How does this PR impact the user?

Users can browse and search beyond the initial results by scrolling the TUI grid or moving right in the detail viewer. Grid prefetching preserves scroll position and focus; detail navigation loads the next batch and advances without requiring a return to the grid.

## Description

- [x] Page empty-query browsing with a stable modification-time and filepath cursor
- [x] Rank each text search once and append its cached results in bounded batches
- [x] Load batches near the end of the grid or when detail navigation reaches the last loaded image
- [x] Cancel pending detail advancement when moving left or returning to the grid, and allow retry after a loading failure
- [x] Keep preview loading and navigation responsive as mounted results grow

## Limitations

- Loaded result cards remain mounted for the browsing session; the grid is not fully virtualized.
- Text search rankings are computed up front; only card mounting and preview decoding are batched.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes