### PR TITLE
perf: cut search time 34–36% and memory 91–94%

### DIFF
--- a/rclip/main.py
+++ b/rclip/main.py
@@ -334,8 +334,11 @@ class RClip:
         )
 
     if top_k is None:
-      return sorted(iter_results(), key=lambda result: (-result.score, result.filepath))
-    return heapq.nsmallest(top_k, iter_results(), key=lambda result: (-result.score, result.filepath))
+      results = sorted(iter_results(), key=lambda result: (-result.score, result.filepath))
+    else:
+      results = heapq.nsmallest(top_k, iter_results(), key=lambda result: (-result.score, result.filepath))
+    helpers.raise_if_cancelled(cancel_event)
+    return results
 
   def list_images(
     self,

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -1,3 +1,5 @@
+import heapq
+import itertools
 import os
 import re
 import sys
@@ -63,6 +65,7 @@ class RClip:
   # cost little memory.
   LOOKAHEAD_BATCHES = 3
   MAX_IMAGE_LOADING_WORKERS = 16
+  SEARCH_BATCH_SIZE = 4096
 
   class SearchResult(NamedTuple):
     filepath: str
@@ -291,28 +294,48 @@ class RClip:
     *,
     cancel_event: threading.Event | None = None,
   ) -> List[SearchResult]:
-    filepaths, features = self._get_features(directory, cancel_event)
-
     positive_queries = [query] + positive_queries
-    sorted_similarities = self._model.compute_similarities_to_text(
-      features, positive_queries, negative_queries, cancel_event=cancel_event
-    )
+    helpers.raise_if_cancelled(cancel_event)
+    positive_features = self._model.compute_features_for_queries(positive_queries)
+    helpers.raise_if_cancelled(cancel_event)
+    negative_features = self._model.compute_features_for_queries(negative_queries)
+    helpers.raise_if_cancelled(cancel_event)
+    query_features = positive_features - negative_features
 
     # exclude images that were part of the query from the results
-    exclude_files = [
+    exclude_files = {
       os.path.abspath(query) for query in positive_queries + negative_queries if helpers.is_file_path(query)
-    ]
+    }
 
-    results: list[RClip.SearchResult] = []
-    for score, index in sorted_similarities:
-      if top_k is not None and len(results) >= top_k:
-        break
-      helpers.raise_if_cancelled(cancel_event)
-      filepath = filepaths[index]
-      if self._exclude_dir_regex.match(filepath) or filepath in exclude_files:
-        continue
-      results.append(RClip.SearchResult(filepath, score))
-    return results
+    def iter_results() -> Iterator[RClip.SearchResult]:
+      images = iter(self._db.get_image_vectors_by_dir_path(directory))
+      while True:
+        batch_size = 0
+        filepaths: list[str] = []
+        features: list[model.FeatureVector] = []
+        for image in itertools.islice(images, self.SEARCH_BATCH_SIZE):
+          helpers.raise_if_cancelled(cancel_event)
+          batch_size += 1
+          filepath = image["filepath"]
+          if self._exclude_dir_regex.match(filepath) or filepath in exclude_files:
+            continue
+          filepaths.append(filepath)
+          features.append(np.frombuffer(image["vector"], np.float32))
+        if not batch_size:
+          break
+        if not features:
+          continue
+        stacked_features = np.stack(features)
+        helpers.raise_if_cancelled(cancel_event)
+        similarities = query_features @ stacked_features.T
+        helpers.raise_if_cancelled(cancel_event)
+        yield from (
+          RClip.SearchResult(filepath, float(score)) for filepath, score in zip(filepaths, similarities)
+        )
+
+    if top_k is None:
+      return sorted(iter_results(), key=lambda result: (-result.score, result.filepath))
+    return heapq.nsmallest(top_k, iter_results(), key=lambda result: (-result.score, result.filepath))
 
   def list_images(
     self,
@@ -334,21 +357,6 @@ class RClip:
       results.append(filepath)
       last_cursor = RClip.ImageCursor(float(row["modified_at"]), filepath)
     return RClip.ImagePage(results, None)
-
-  def _get_features(
-    self, directory: str, cancel_event: threading.Event | None = None
-  ) -> Tuple[List[str], model.FeatureVector]:
-    filepaths: List[str] = []
-    features: List[model.FeatureVector] = []
-    for image in self._db.get_image_vectors_by_dir_path(directory):
-      helpers.raise_if_cancelled(cancel_event)
-      filepaths.append(image["filepath"])
-      features.append(np.frombuffer(image["vector"], np.float32))
-    if not filepaths:
-      return [], np.ndarray(shape=(0, model.Model.VECTOR_SIZE))
-    stacked_features = np.stack(features)
-    helpers.raise_if_cancelled(cancel_event)
-    return filepaths, stacked_features
 
 
 def init_rclip(

--- a/rclip/model.py
+++ b/rclip/model.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from threading import Event
 from typing import Any, List, Optional, Tuple
 
 import numpy as np
@@ -195,30 +194,3 @@ class Model:
     if image_features is None:
       return text_features
     return text_features + image_features
-
-  def compute_similarities_to_text(
-    self,
-    item_features: FeatureVector,
-    positive_queries: List[str],
-    negative_queries: List[str],
-    *,
-    cancel_event: Event | None = None,
-  ) -> List[Tuple[float, int]]:
-    helpers.raise_if_cancelled(cancel_event)
-    positive_features = self.compute_features_for_queries(positive_queries)
-    helpers.raise_if_cancelled(cancel_event)
-    negative_features = self.compute_features_for_queries(negative_queries)
-    helpers.raise_if_cancelled(cancel_event)
-
-    features = positive_features - negative_features
-
-    similarities = features @ item_features.T
-    helpers.raise_if_cancelled(cancel_event)
-    sorted_similarities = sorted(
-      zip(similarities, range(item_features.shape[0])),
-      key=lambda similarity_with_index: similarity_with_index[0],
-      reverse=True,
-    )
-    helpers.raise_if_cancelled(cancel_event)
-
-    return sorted_similarities

--- a/tests/unit/test_index_images.py
+++ b/tests/unit/test_index_images.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from threading import Event
-from unittest.mock import Mock
+from unittest.mock import call, Mock
 import tempfile
 
 import numpy as np
@@ -8,6 +8,7 @@ import PIL
 from PIL import Image
 import pytest
 
+from rclip import main as main_module
 from rclip.db import DB, NewImage
 from rclip.main import ImageMeta, RClip
 from rclip.utils import helpers
@@ -40,25 +41,85 @@ def test_search_stops_loading_vectors_when_cancelled() -> None:
 
   database.get_image_vectors_by_dir_path.side_effect = rows
   model = Mock()
+  model.compute_features_for_queries.return_value = np.zeros(512, dtype=np.float32)
   rclip = _make_rclip(model, database)
 
   with pytest.raises(InterruptedError):
     rclip.search("cat", ".", cancel_event=cancel_event)
-  model.compute_similarities_to_text.assert_not_called()
 
 
-def test_search_can_return_every_ranked_result() -> None:
+def test_search_stops_between_query_groups_when_cancelled() -> None:
+  cancel_event = Event()
+  model = Mock()
+  calls: list[list[str]] = []
+
+  def compute(queries: list[str]) -> np.ndarray:
+    calls.append(queries)
+    cancel_event.set()
+    return np.zeros(512, dtype=np.float32)
+
+  model.compute_features_for_queries.side_effect = compute
+  database = Mock()
+  rclip = _make_rclip(model, database)
+
+  with pytest.raises(InterruptedError):
+    rclip.search("cat", ".", cancel_event=cancel_event)
+  assert calls == [["cat"]]
+  database.get_image_vectors_by_dir_path.assert_not_called()
+
+
+def test_search_keeps_only_global_top_results_across_vector_batches(monkeypatch) -> None:
+  model = Mock()
+  model.compute_features_for_queries.side_effect = [
+    np.array([1, 0], dtype=np.float32),
+    np.array([0, 0], dtype=np.float32),
+  ]
   database = Mock()
   database.get_image_vectors_by_dir_path.return_value = [
-    {"filepath": f"{index}.jpg", "vector": np.zeros(512, dtype=np.float32).tobytes()}
+    {"filepath": filepath, "vector": np.array(vector, dtype=np.float32).tobytes()}
+    for filepath, vector in (
+      ("z.jpg", [0.8, 0]),
+      ("b.jpg", [0.9, 0]),
+      ("c.jpg", [0.2, 0]),
+      ("a.jpg", [0.9, 0]),
+      ("d.jpg", [0.7, 0]),
+    )
+  ]
+  rclip = _make_rclip(model, database)
+  monkeypatch.setattr(RClip, "SEARCH_BATCH_SIZE", 2)
+  batch_sizes: list[int] = []
+  stack = main_module.np.stack
+
+  def record_stack(features):
+    batch_sizes.append(len(features))
+    return stack(features)
+
+  monkeypatch.setattr(main_module.np, "stack", record_stack)
+
+  results = rclip.search("cat", ".", 3, ["bright"], ["dark"])
+
+  assert [result.filepath for result in results] == ["a.jpg", "b.jpg", "z.jpg"]
+  np.testing.assert_allclose([result.score for result in results], [0.9, 0.9, 0.8])
+  assert model.compute_features_for_queries.call_args_list == [call(["cat", "bright"]), call(["dark"])]
+  assert batch_sizes == [2, 2, 1]
+
+
+def test_search_can_return_every_ranked_result(monkeypatch) -> None:
+  monkeypatch.setattr(RClip, "SEARCH_BATCH_SIZE", 2)
+  database = Mock()
+  database.get_image_vectors_by_dir_path.return_value = [
+    {"filepath": f"{index}.jpg", "vector": np.array([index, 0], dtype=np.float32).tobytes()}
     for index in range(12)
   ]
   model = Mock()
-  model.compute_similarities_to_text.return_value = [(float(index), index) for index in range(12)]
+  model.compute_features_for_queries.side_effect = [
+    np.array([1, 0], dtype=np.float32),
+    np.array([0, 0], dtype=np.float32),
+  ]
   rclip = _make_rclip(model, database)
 
   assert rclip.search("cat", ".", top_k=None) == [
-    RClip.SearchResult(f"{index}.jpg", float(index)) for index in range(12)
+    RClip.SearchResult(f"{index}.jpg", float(index)) for index in reversed(range(12))
   ]
 
 

--- a/tests/unit/test_index_images.py
+++ b/tests/unit/test_index_images.py
@@ -68,6 +68,55 @@ def test_search_stops_between_query_groups_when_cancelled() -> None:
   database.get_image_vectors_by_dir_path.assert_not_called()
 
 
+def test_search_stops_when_cancelled_during_final_sort(monkeypatch) -> None:
+  cancel_event = Event()
+  model = Mock()
+  model.compute_features_for_queries.return_value = np.zeros(2, dtype=np.float32)
+  database = Mock()
+  database.get_image_vectors_by_dir_path.return_value = [
+    {"filepath": "a.jpg", "vector": np.zeros(2, dtype=np.float32).tobytes()}
+  ]
+
+  def sort_results(results, *, key):
+    def cancelling_key(result):
+      cancel_event.set()
+      return key(result)
+
+    return sorted(results, key=cancelling_key)
+
+  monkeypatch.setattr(main_module, "sorted", sort_results, raising=False)
+  rclip = _make_rclip(model, database)
+
+  with pytest.raises(InterruptedError):
+    rclip.search("cat", ".", top_k=None, cancel_event=cancel_event)
+
+
+@pytest.mark.parametrize("top_k", [1, None])
+def test_search_continues_after_an_entirely_excluded_batch(monkeypatch, tmp_path: Path, top_k) -> None:
+  monkeypatch.setattr(RClip, "SEARCH_BATCH_SIZE", 2)
+  model = Mock()
+  model.compute_features_for_queries.side_effect = [
+    np.array([1, 0], dtype=np.float32),
+    np.zeros(2, dtype=np.float32),
+  ]
+  database = Mock()
+  database.get_image_vectors_by_dir_path.return_value = [
+    {"filepath": str(tmp_path / filepath), "vector": np.array([score, 0], dtype=np.float32).tobytes()}
+    for filepath, score in (
+      ("private/a.jpg", 4),
+      ("query.jpg", 3),
+      ("b.jpg", 1),
+      ("a.jpg", 2),
+    )
+  ]
+  rclip = _make_rclip(model, database, ["private"])
+
+  assert rclip.search(str(tmp_path / "query.jpg"), str(tmp_path), top_k=top_k) == [
+    RClip.SearchResult(str(tmp_path / "a.jpg"), 2),
+    RClip.SearchResult(str(tmp_path / "b.jpg"), 1),
+  ][:top_k]
+
+
 def test_search_keeps_only_global_top_results_across_vector_batches(monkeypatch) -> None:
   model = Mock()
   model.compute_features_for_queries.side_effect = [

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import sys
 import tempfile
-from threading import Event
 import types
 from typing import Callable, cast
 
@@ -49,25 +48,6 @@ class FakeInferenceSession:
 
   def get_inputs(self) -> list[object]:
     return [types.SimpleNamespace(type="tensor(float)")]
-
-
-def test_similarity_stops_between_query_groups_when_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
-  model = Model()
-  cancel_event = Event()
-  calls: list[list[str]] = []
-
-  def compute(queries: list[str]) -> np.ndarray:
-    calls.append(queries)
-    cancel_event.set()
-    return np.zeros(2, dtype=np.float32)
-
-  monkeypatch.setattr(model, "compute_features_for_queries", compute)
-
-  with pytest.raises(InterruptedError):
-    model.compute_similarities_to_text(
-      np.zeros((1, 2), dtype=np.float32), ["cat"], ["dog"], cancel_event=cancel_event
-    )
-  assert calls == [["cat"]]
 
 
 def test_download_coreml_model_materializes_real_package(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## How does this PR impact the user?

Searches score vectors in fixed-size chunks, retaining only the requested top results for limited searches and the full ranking for TUI pagination.

On an existing **1,281,167-image ImageNet index**, median search time decreased **34–36%** and median peak process memory decreased **91–94%**:

| Search | Main time | PR time | Main peak memory | PR peak memory |
|---|---:|---:|---:|---:|
| Top 10 | 10.12 s | 6.63 s | 11.30 GiB | 0.63 GiB |
| Full ranking (TUI search) | 11.78 s | 7.57 s | 11.30 GiB | 1.05 GiB |

Three text queries repeated twice per implementation and search mode (24 searches), alternating implementations in fresh processes on macOS arm64 with a warmed real model and read-only index. Timing includes query inference, SQLite retrieval, scoring, and ranking; excludes startup, indexing, and UI rendering. OS caches were not flushed. All result paths, ordering, and scores matched exactly; the index remained unchanged.

## Description

- [x] Score database vectors in fixed-size chunks
- [x] Keep limited searches' global top results with bounded heap memory
- [x] Preserve query weighting, exclusions, cancellation, and deterministic result ordering
- [x] Preserve unlimited ranked results for TUI pagination
- [x] Check cancellation after final ranking and cover fully excluded batches with regression tests

## Limitations

- Search still reads and scores every matching vector.
- Ranking memory grows with `--top`; TUI searches retain and sort all matching results for pagination.
- Benchmark improvements depend on the index, query, hardware, and cache state.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
