### PR TITLE
Build AppImage with Python 3.13

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -243,7 +243,7 @@ jobs:
       - uses: ./.github/actions/setup-syft
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - run: sudo apt-get install -y fuse
       - name: Install appimage-builder
         run: |

--- a/release-utils/appimage/appimage-builder.yml
+++ b/release-utils/appimage/appimage-builder.yml
@@ -35,10 +35,8 @@ AppDir:
 
     include:
       - libffi7
-      - libpython3.13-minimal
       - libpython3.13-stdlib
       - python3.13
-      - python3.13-minimal
       - python3.13-venv
     exclude: []
 

--- a/release-utils/appimage/appimage-builder.yml
+++ b/release-utils/appimage/appimage-builder.yml
@@ -27,9 +27,9 @@ AppDir:
     arch: amd64
     sources:
       - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy main restricted universe multiverse'
-        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
+        key_url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
       - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main restricted'
-        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
+        key_url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
       - sourceline: 'deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main'
         key_url: 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xba6932366a755776'
 
@@ -52,11 +52,11 @@ AppDir:
       PYTHONHOME: '${APPDIR}/usr'
       # Path to the site-packages dir or other modules dirs
       # See https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH
-      PYTHONPATH: '${APPDIR}/usr/src:${APPDIR}/usr/lib/python3.13/site-packages'
+      PYTHONPATH: '${APPDIR}/usr/src:${APPDIR}/usr/local/lib/python3.13/site-packages'
       # SSL Certificates are placed in a different location for every system therefore we ship our own copy
-      SSL_CERT_FILE: '${APPDIR}/usr/lib/python3.13/site-packages/certifi/cacert.pem'
+      SSL_CERT_FILE: '${APPDIR}/usr/local/lib/python3.13/site-packages/certifi/cacert.pem'
       # requests (used by huggingface_hub) checks REQUESTS_CA_BUNDLE before certifi.where()
-      REQUESTS_CA_BUNDLE: '${APPDIR}/usr/lib/python3.13/site-packages/certifi/cacert.pem'
+      REQUESTS_CA_BUNDLE: '${APPDIR}/usr/local/lib/python3.13/site-packages/certifi/cacert.pem'
 
   test:
     fedora:

--- a/release-utils/appimage/appimage-builder.yml
+++ b/release-utils/appimage/appimage-builder.yml
@@ -19,7 +19,7 @@ AppDir:
     icon: rclip
     version: !ENV ${APP_VERSION}
     # Set the python executable as entry point
-    exec: usr/bin/python3.11
+    exec: usr/bin/python3.13
     # Set the application main script path as argument. Use '$@' to forward CLI parameters
     exec_args: "${APPDIR}/usr/local/bin/rclip $@"
 
@@ -35,12 +35,11 @@ AppDir:
 
     include:
       - libffi7
-      - libpython3.11-minimal
-      - libpython3.11-stdlib
-      - python3.11
-      - python3.11-minimal
-      - python3-pip
-      - python3-distutils
+      - libpython3.13-minimal
+      - libpython3.13-stdlib
+      - python3.13
+      - python3.13-minimal
+      - python3.13-venv
     exclude: []
 
   after_bundle: |
@@ -55,11 +54,11 @@ AppDir:
       PYTHONHOME: '${APPDIR}/usr'
       # Path to the site-packages dir or other modules dirs
       # See https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH
-      PYTHONPATH: '${APPDIR}/usr/src:${APPDIR}/usr/lib/python3.11/site-packages'
+      PYTHONPATH: '${APPDIR}/usr/src:${APPDIR}/usr/lib/python3.13/site-packages'
       # SSL Certificates are placed in a different location for every system therefore we ship our own copy
-      SSL_CERT_FILE: '${APPDIR}/usr/lib/python3.11/site-packages/certifi/cacert.pem'
+      SSL_CERT_FILE: '${APPDIR}/usr/lib/python3.13/site-packages/certifi/cacert.pem'
       # requests (used by huggingface_hub) checks REQUESTS_CA_BUNDLE before certifi.where()
-      REQUESTS_CA_BUNDLE: '${APPDIR}/usr/lib/python3.11/site-packages/certifi/cacert.pem'
+      REQUESTS_CA_BUNDLE: '${APPDIR}/usr/lib/python3.13/site-packages/certifi/cacert.pem'
 
   test:
     fedora:

--- a/release-utils/appimage/appimage_after_bundle.sh
+++ b/release-utils/appimage/appimage_after_bundle.sh
@@ -3,27 +3,26 @@
 set -euo pipefail
 
 export PYTHONHOME="$APPDIR/usr"
-export PYTHONPATH="$APPDIR/usr/lib/python3/dist-packages:$APPDIR/usr/lib/python3.13:$APPDIR/usr/lib/python3.13/site-packages:$APPDIR/usr/local/lib/python3.13/dist-packages"
+export PYTHONPATH="$APPDIR/usr/lib/python3/dist-packages:$APPDIR/usr/lib/python3.13:$APPDIR/usr/local/lib/python3.13/site-packages"
 export LD_LIBRARY_PATH="$APPDIR/usr/lib/x86_64-linux-gnu"
 
 RCLIP_BUILD_TOOLS_DIR=$(mktemp -d)
 trap 'rm -rf "$RCLIP_BUILD_TOOLS_DIR"' EXIT
 python3.13 -m venv "$RCLIP_BUILD_TOOLS_DIR"
-"$RCLIP_BUILD_TOOLS_DIR/bin/python" -m pip install --isolated --no-input uv==0.11.12
-export PYTHONPATH="$RCLIP_BUILD_TOOLS_DIR/lib/python3.13/site-packages:$PYTHONPATH"
+build_python="$RCLIP_BUILD_TOOLS_DIR/bin/python"
+"$build_python" -m pip install --isolated --no-input uv==0.11.12
 
-python3.13 -m uv build
-python3.13 -m uv export --locked --format requirements.txt --no-dev --no-editable --no-emit-project --no-hashes --output-file requirements.txt
-python3.13 -m pip install --upgrade --isolated --no-input --ignore-installed --prefix="$APPDIR/usr" -r requirements.txt
-python3.13 -m pip install --no-dependencies --isolated --no-input --prefix="$APPDIR/usr" dist/*.whl
-python3.13 -m pip install --upgrade --isolated --no-input --ignore-installed --target="$APPDIR/usr/lib/python3.13/site-packages" certifi
+"$build_python" -m uv build
+"$build_python" -m uv export --locked --format requirements.txt --no-dev --no-editable --no-emit-project --no-hashes --output-file requirements.txt
+"$build_python" -m pip install --upgrade --isolated --no-input --ignore-installed --root="$APPDIR" --prefix=/usr/local -r requirements.txt
+"$build_python" -m pip install --no-dependencies --isolated --no-input --root="$APPDIR" --prefix=/usr/local dist/*.whl
+"$build_python" -m pip install --upgrade --isolated --no-input --ignore-installed --target="$APPDIR/usr/local/lib/python3.13/site-packages" certifi
 
 # The bundled pip, setuptools, and wheel packages are build tools inherited
 # from the Ubuntu Python packages. They are not needed by the application.
 for site_packages in \
   "$APPDIR/usr/lib/python3/dist-packages" \
-  "$APPDIR/usr/lib/python3.13/site-packages" \
-  "$APPDIR/usr/local/lib/python3.13/dist-packages"; do
+  "$APPDIR/usr/local/lib/python3.13/site-packages"; do
   if [[ -d "$site_packages" ]]; then
     find "$site_packages" -maxdepth 1 \
       \( -name pip -o -name 'pip-*.dist-info' \

--- a/release-utils/appimage/appimage_after_bundle.sh
+++ b/release-utils/appimage/appimage_after_bundle.sh
@@ -3,26 +3,27 @@
 set -euo pipefail
 
 export PYTHONHOME="$APPDIR/usr"
-export PYTHONPATH="$APPDIR/usr/lib/python3/dist-packages:$APPDIR/usr/lib/python3.11:$APPDIR/usr/lib/python3.11/site-packages:$APPDIR/usr/local/lib/python3.11/dist-packages"
+export PYTHONPATH="$APPDIR/usr/lib/python3/dist-packages:$APPDIR/usr/lib/python3.13:$APPDIR/usr/lib/python3.13/site-packages:$APPDIR/usr/local/lib/python3.13/dist-packages"
 export LD_LIBRARY_PATH="$APPDIR/usr/lib/x86_64-linux-gnu"
 
 RCLIP_BUILD_TOOLS_DIR=$(mktemp -d)
 trap 'rm -rf "$RCLIP_BUILD_TOOLS_DIR"' EXIT
-python3.11 -m pip install --isolated --no-input --target="$RCLIP_BUILD_TOOLS_DIR" uv==0.11.12
-export PYTHONPATH="$RCLIP_BUILD_TOOLS_DIR:$PYTHONPATH"
+python3.13 -m venv "$RCLIP_BUILD_TOOLS_DIR"
+"$RCLIP_BUILD_TOOLS_DIR/bin/python" -m pip install --isolated --no-input uv==0.11.12
+export PYTHONPATH="$RCLIP_BUILD_TOOLS_DIR/lib/python3.13/site-packages:$PYTHONPATH"
 
-python3.11 -m uv build
-python3.11 -m uv export --locked --format requirements.txt --no-dev --no-editable --no-emit-project --no-hashes --output-file requirements.txt
-python3.11 -m pip install --upgrade --isolated --no-input --ignore-installed --prefix="$APPDIR/usr" -r requirements.txt
-python3.11 -m pip install --no-dependencies --isolated --no-input --prefix="$APPDIR/usr" dist/*.whl
-python3.11 -m pip install --upgrade --isolated --no-input --ignore-installed --target="$APPDIR/usr/lib/python3.11/site-packages" certifi
+python3.13 -m uv build
+python3.13 -m uv export --locked --format requirements.txt --no-dev --no-editable --no-emit-project --no-hashes --output-file requirements.txt
+python3.13 -m pip install --upgrade --isolated --no-input --ignore-installed --prefix="$APPDIR/usr" -r requirements.txt
+python3.13 -m pip install --no-dependencies --isolated --no-input --prefix="$APPDIR/usr" dist/*.whl
+python3.13 -m pip install --upgrade --isolated --no-input --ignore-installed --target="$APPDIR/usr/lib/python3.13/site-packages" certifi
 
 # The bundled pip, setuptools, and wheel packages are build tools inherited
 # from the Ubuntu Python packages. They are not needed by the application.
 for site_packages in \
   "$APPDIR/usr/lib/python3/dist-packages" \
-  "$APPDIR/usr/lib/python3.11/site-packages" \
-  "$APPDIR/usr/local/lib/python3.11/dist-packages"; do
+  "$APPDIR/usr/lib/python3.13/site-packages" \
+  "$APPDIR/usr/local/lib/python3.13/dist-packages"; do
   if [[ -d "$site_packages" ]]; then
     find "$site_packages" -maxdepth 1 \
       \( -name pip -o -name 'pip-*.dist-info' \
@@ -38,7 +39,7 @@ for bin_dir in "$APPDIR/usr/bin" "$APPDIR/usr/local/bin"; do
   fi
 done
 
-python3.11 -m rclip._compliance collect \
+python3.13 -m rclip._compliance collect \
   --root "$APPDIR" \
   --output "$APPDIR/usr/share/doc/rclip" \
   --policy compliance/policy.toml \


### PR DESCRIPTION
## How does this PR impact the user?

The Linux AppImage now runs rclip on Python 3.13, the newest Python version currently supported by the project.

## Description

- [x] Bundle Python 3.13 and update the AppImage runtime paths.
- [x] Bootstrap the pinned build tooling in an isolated Python 3.13 virtual environment.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
