### PR TITLE
fix: preserve excluded images and scope filters to the search directory

### DIFF
--- a/rclip/db.py
+++ b/rclip/db.py
@@ -160,6 +160,11 @@ class DB:
     cur = self._con.execute(f"SELECT * FROM images WHERE {query} LIMIT 1", kwargs)
     return cur.fetchone()
 
+  def restore_image(self, filepath: str, commit: bool = True):
+    self._con.execute("UPDATE images SET deleted = NULL, indexing = NULL WHERE filepath = ?", (filepath,))
+    if commit:
+      self._con.commit()
+
   def get_images_by_hash(self, hash_value: str, file_size: int) -> list[Image]:
     cur = self._con.execute(
       "SELECT * FROM images WHERE hash = ? AND size = ? AND deleted IS NULL",

--- a/rclip/fs.py
+++ b/rclip/fs.py
@@ -36,7 +36,7 @@ def walk(
         if skip_hidden and entry.name.startswith("."):
           continue
         if entry.is_dir():
-          if not exclude_dir_re.match(entry.path):
+          if not exclude_dir_re.match(os.path.join(".", os.path.relpath(entry.path, directory))):
             dirs_to_process.append(entry.path)
         elif entry.is_file() and file_re.match(entry.name):
           yield entry

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -255,7 +255,10 @@ class RClip:
 
       image = self._db.get_image(filepath=filepath)
       if image and is_image_meta_equal(image, meta):
-        self._db.restore_image(filepath, commit=False)
+        if image["deleted"]:
+          self._db.restore_image(filepath, commit=False)
+        else:
+          self._db.remove_indexing_flag(filepath, commit=False)
         continue
 
       yield filepath, meta

--- a/rclip/main.py
+++ b/rclip/main.py
@@ -110,6 +110,12 @@ class RClip:
       self._image_loading_executor = ThreadPoolExecutor(max_workers=self._image_loading_workers)
     return self._image_loading_executor
 
+  def _is_excluded(self, filepath: str, directory: str) -> bool:
+    relative_path = os.path.relpath(filepath, directory)
+    if self._skip_hidden and any(part.startswith(".") for part in relative_path.split(os.path.sep)):
+      return True
+    return self._exclude_dir_regex.match(os.path.join(".", os.path.dirname(relative_path))) is not None
+
   def _shutdown_image_loading_executor(self) -> None:
     if self._image_loading_executor is None:
       return
@@ -249,7 +255,7 @@ class RClip:
 
       image = self._db.get_image(filepath=filepath)
       if image and is_image_meta_equal(image, meta):
-        self._db.remove_indexing_flag(filepath, commit=False)
+        self._db.restore_image(filepath, commit=False)
         continue
 
       yield filepath, meta
@@ -263,6 +269,10 @@ class RClip:
 
     self._db.remove_indexing_flag_from_all_images(commit=False)
     self._db.flag_images_in_a_dir_as_indexing(directory, commit=True)
+    # Excluded paths were not inspected, so leave their cached state alone.
+    for row in self._db.get_image_filepaths_by_dir_path(directory):
+      if self._is_excluded(row["filepath"], directory):
+        self._db.remove_indexing_flag(row["filepath"], commit=False)
 
     with tqdm(total=None, unit="images") as pbar:
 
@@ -317,7 +327,7 @@ class RClip:
           helpers.raise_if_cancelled(cancel_event)
           batch_size += 1
           filepath = image["filepath"]
-          if self._exclude_dir_regex.match(filepath) or filepath in exclude_files:
+          if self._is_excluded(filepath, directory) or filepath in exclude_files:
             continue
           filepaths.append(filepath)
           features.append(np.frombuffer(image["vector"], np.float32))
@@ -353,7 +363,7 @@ class RClip:
     for row in self._db.get_image_filepaths_by_dir_path(directory, after):
       helpers.raise_if_cancelled(cancel_event)
       filepath = row["filepath"]
-      if self._exclude_dir_regex.match(filepath):
+      if self._is_excluded(filepath, directory):
         continue
       if len(results) == limit:
         return RClip.ImagePage(results, last_cursor)

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -358,7 +358,7 @@ def init_arg_parser() -> argparse.ArgumentParser:
     "--include-hidden",
     action="store_true",
     default=False,
-    help="index dot-prefixed hidden files and directories"
+    help="index and search dot-prefixed hidden files and directories"
     " (e.g. .DS_Store, ._IMG_1234.JPG, .Spotlight-V100);"
     " by default they are skipped since they are usually OS metadata rather than user files",
   )

--- a/tests/unit/test_fs.py
+++ b/tests/unit/test_fs.py
@@ -2,6 +2,8 @@ import os
 import re
 from pathlib import Path
 
+import pytest
+
 from rclip import fs
 
 IMAGE_RE = re.compile(r"^.+\.(jpg|jpeg|png)$", re.I)
@@ -47,3 +49,14 @@ def test_walk_include_hidden_indexes_dot_files_and_dirs(tmp_path: Path):
 
   # .DS_Store doesn't match the image regex regardless, but the sidecar-like hidden dir now gets walked
   assert _walked_names(tmp_path, skip_hidden=False) == ["hidden.jpg", "photo.jpg"]
+
+
+@pytest.mark.parametrize("ancestor", [".worktrees", ".git", "node_modules"])
+def test_walk_exclusions_are_relative_to_root(tmp_path: Path, ancestor: str):
+  root = tmp_path / ancestor / "checkout"
+  _touch(root / "photo.jpg")
+  _touch(root / "nested" / "nested.jpg")
+  _touch(root / ".hidden.jpg")
+  _touch(root / "node_modules" / "excluded.jpg")
+
+  assert _walked_names(root) == ["nested.jpg", "photo.jpg"]

--- a/tests/unit/test_index_images.py
+++ b/tests/unit/test_index_images.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 from threading import Event
 from unittest.mock import call, Mock
 import tempfile
@@ -360,4 +361,102 @@ def test_same_hash_different_size_reindexes(monkeypatch):
     assert new_record["vector"] != old_vector
     assert new_record["hash"] == old_hash
 
+    database.close()
+
+
+@pytest.mark.parametrize(
+  "excluded_name,include_hidden,exclude_dirs",
+  [(".worktrees", False, None), (".git", True, None), ("private", True, ["private"])],
+)
+def test_exclusions_preserve_cache_and_apply_to_search_and_browse(
+  tmp_path: Path, excluded_name: str, include_hidden: bool, exclude_dirs: list[str] | None
+):
+  # The same excluded name above the search root must not affect its descendants.
+  root = tmp_path / excluded_name / "checkout"
+  visible = root / "nested" / "photo.jpg"
+  excluded = root / excluded_name / "photo.jpg"
+  dotfile = root / ".photo.jpg"
+  for path in (visible, excluded, dotfile):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (2, 2)).save(path)
+
+  database = DB(tmp_path / "db.sqlite3")
+  model = Mock()
+  model.compute_preprocessed_image_features.side_effect = lambda images, **kwargs: np.ones(
+    (len(images), 512), dtype=np.float32
+  )
+  model.compute_features_for_queries.return_value = np.zeros(512, dtype=np.float32)
+  enabled = RClip(model, database, 8, ["unused"], include_hidden=True)
+  restricted = RClip(model, database, 8, exclude_dirs, include_hidden=include_hidden)
+
+  def results(app: RClip, expected: set[str]):
+    assert {row.filepath for row in app.search("cat", str(root), 10)} == expected
+    assert set(app.list_images(str(root), 10).filepaths) == expected
+    assert len(app.search("cat", str(root), 1)) == 1
+    page = app.list_images(str(root), 1)
+    browsed = list(page.filepaths)
+    assert len(browsed) == 1
+    while page.next_cursor is not None:
+      page = app.list_images(str(root), 1, after=page.next_cursor)
+      browsed.extend(page.filepaths)
+    assert set(browsed) == expected
+    assert len(browsed) == len(expected)
+
+  all_paths = {str(visible), str(excluded), str(dotfile)}
+  visible_paths = {str(visible), str(dotfile)} if include_hidden else {str(visible)}
+  try:
+    enabled.ensure_index(str(root))
+    model.compute_preprocessed_image_features.reset_mock()
+    results(enabled, all_paths)
+    results(restricted, visible_paths)  # --no-indexing must still filter cached results.
+    restricted.ensure_index(str(root))
+    results(restricted, visible_paths)
+    results(enabled, all_paths)
+    enabled.ensure_index(str(root))
+    results(enabled, all_paths)
+    model.compute_preprocessed_image_features.assert_not_called()
+
+    # A parent scan excludes this entire checkout; searching inside it still works.
+    restricted.ensure_index(str(tmp_path))
+    restricted.ensure_index(str(root))
+    results(restricted, visible_paths)
+    results(enabled, all_paths)
+
+    excluded.unlink()
+    restricted.ensure_index(str(root))
+    results(enabled, all_paths)  # Out-of-scope deletions remain unverified.
+    enabled.ensure_index(str(root))
+    results(enabled, all_paths - {str(excluded)})
+  finally:
+    enabled.close()
+    restricted.close()
+    database.close()
+
+
+def test_index_restores_unchanged_deleted_image(tmp_path: Path):
+  photo = tmp_path / "photo.jpg"
+  photo.touch()
+  stat = photo.stat()
+  vector = np.ones(512, dtype=np.float32).tobytes()
+  database = DB(tmp_path / "db.sqlite3")
+  database.upsert_image(
+    NewImage(filepath=str(photo), modified_at=stat.st_mtime, size=stat.st_size, vector=vector, hash=None)
+  )
+  model = Mock()
+  app = _make_rclip(model, database)
+  try:
+    photo.unlink()
+    app.ensure_index(str(tmp_path))
+    assert app.list_images(str(tmp_path), 10).filepaths == []
+    photo.touch()
+    os.utime(photo, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+    app.ensure_index(str(tmp_path))
+    assert app.list_images(str(tmp_path), 10).filepaths == [str(photo)]
+    restored = database.get_image(filepath=str(photo))
+    assert restored is not None
+    assert restored["deleted"] is None
+    assert restored["vector"] == vector
+    model.compute_preprocessed_image_features.assert_not_called()
+  finally:
+    app.close()
     database.close()


### PR DESCRIPTION
## How does this PR impact the user?

- Hidden files and excluded directories stay out of search and TUI results, including with `--no-indexing`, without losing their cached state. Searches inside hidden or excluded directories work normally.

## Description

- Apply exclusions relative to the search root, preserve excluded cache entries, and restore rediscovered images without recomputing unchanged vectors.
- Cover flag toggling, parent/child scans, pagination, and deletion/restoration with regression tests. Validation: 170 unit tests, Ruff, and ty pass.

## Limitations

- Deletions in excluded paths are detected when those paths are next included in indexing.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
