### PR TITLE
feat: switch `--preview` to use Kitty graphics and force Kitty graphics for `--interactive` (because the TUI isn't built for Sixel anyway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Open the interactive UI and enter a query in its search input:
 rclip --interactive
 ```
 
-The UI requires Kitty graphics with Unicode-placeholder support. There is no fallback for unsupported terminals, which may show missing images or garbled placeholders. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches are ranked once and loaded in batches of up to 100 results as you scroll; pass `--top N` to use a smaller search batch. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and opening a result loads a higher-resolution display image.
+The UI requires Kitty graphics with Unicode-placeholder support. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches are ranked once and loaded in batches of up to 100 results as you scroll; pass `--top N` to use a smaller search batch. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and opening a result loads a higher-resolution display image.
 
 | Key | Action |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ are indexed instead of the RAW original.
 
 ### How do I preview the results?
 
-In a terminal supporting Kitty graphics, such as [Kitty](https://sw.kovidgoyal.net/kitty/), [Ghostty](https://ghostty.org/), or recent [iTerm2](https://iterm2.com/), pass the `--preview` (or `-p`) flag to **rclip**. Graphics support is not detected; unsupported terminals may show missing images or escape-sequence text:
+In a terminal supporting Kitty graphics, such as [Kitty](https://sw.kovidgoyal.net/kitty/), [Ghostty](https://ghostty.org/), latest [iTerm2](https://iterm2.com/), or [Konsole](https://konsole.kde.org/), pass the `--preview` (or `-p`) flag to **rclip**. Graphics support is not detected; unsupported terminals may show missing images or escape-sequence text:
 
 ```bash
 rclip -p kitty
@@ -254,7 +254,7 @@ Run `rclip --help` (or `rclip -h`) to see this list in your terminal. The positi
 | `--subtract`, `--sub`, `-s`, `-` `QUERY` | A text query or a path/URL to an image file to subtract from the "original" query. Can be used multiple times. |
 | `--top`, `-t` `N` | Number of top results to display, or search results to load per batch with `--interactive`. Default: `10`, or `100` with `--interactive`; interactive maximum: `100`. |
 | `--interactive`, `-i` | Open the interactive terminal UI and enter text queries there. Does not accept a positional query or `--add`/`--subtract`. Mutually exclusive with `--preview` and `--filepath-only`. |
-| `--preview`, `-p` | Preview results in the terminal (requires Kitty graphics). Mutually exclusive with `--filepath-only`. |
+| `--preview`, `-p` | Preview results in the terminal using Kitty graphics (e.g. Kitty, Ghostty, latest iTerm2, Konsole). Mutually exclusive with `--filepath-only`. |
 | `--filepath-only`, `-f` | Output only filepaths, without scores or the header. Mutually exclusive with `--preview`. |
 | `--preview-height`, `-H` `PX` | Preview height in pixels. Default: `400`. |
 | `--no-indexing`, `--skip-index`, `--skip-indexing`, `-n` | Skip updating the index. Use only when no images were added, changed, or removed since the last run. |

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ are indexed instead of the RAW original.
 
 ### How do I preview the results?
 
-In a terminal supporting Kitty graphics, such as [Kitty](https://sw.kovidgoyal.net/kitty/), [Ghostty](https://ghostty.org/), latest [iTerm2](https://iterm2.com/), or [Konsole](https://konsole.kde.org/), pass the `--preview` (or `-p`) flag to **rclip**. Graphics support is not detected; unsupported terminals may show missing images or escape-sequence text:
+In a terminal supporting Kitty graphics, such as [Kitty](https://sw.kovidgoyal.net/kitty/), [Ghostty](https://ghostty.org/), latest [iTerm2](https://iterm2.com/), or [Konsole](https://konsole.kde.org/), pass the `--preview` (or `-p`) flag to **rclip**:
 
 ```bash
 rclip -p kitty

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ rclip "two parrots on a branch"
   macOS/Windows and experimental RAW (`arw`, `cr2`, `dng`).
 - **Fast incremental indexing** – only new and changed images are reprocessed on subsequent runs.
 - **Interactive terminal UI** – search a responsive thumbnail grid without leaving the terminal.
-- **Terminal previews** – view images inline in iTerm2, Konsole, wezterm, Mintty, and mlterm.
+- **Terminal previews** – view images inline in terminals supporting Kitty graphics.
 - **Cross-platform** – Linux, macOS (Apple Silicon), and Windows.
 
 ## Installation
@@ -126,7 +126,7 @@ Open the interactive UI and enter a query in its search input:
 rclip --interactive
 ```
 
-The UI uses Kitty's graphics protocol when available and Sixel in terminals such as iTerm2, with a colored half-cell fallback elsewhere. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches are ranked once and loaded in batches of up to 100 results as you scroll; pass `--top N` to use a smaller search batch. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and opening a result loads a higher-resolution display image.
+The UI requires Kitty graphics with Unicode-placeholder support. There is no fallback for unsupported terminals, which may show missing images or garbled placeholders. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches are ranked once and loaded in batches of up to 100 results as you scroll; pass `--top N` to use a smaller search batch. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and opening a result loads a higher-resolution display image.
 
 | Key | Action |
 | --- | --- |
@@ -193,7 +193,7 @@ are indexed instead of the RAW original.
 
 ### How do I preview the results?
 
-If you are using either [iTerm2](https://iterm2.com/), [Konsole](https://konsole.kde.org/) (version 22.04 and higher), [wezterm](https://wezfurlong.org/wezterm/), [Mintty](https://mintty.github.io/), or [mlterm](https://mlterm.sourceforge.net/), all you need to do is pass the `--preview` (or `-p`) flag to **rclip**:
+In a terminal supporting Kitty graphics, such as [Kitty](https://sw.kovidgoyal.net/kitty/), [Ghostty](https://ghostty.org/), or recent [iTerm2](https://iterm2.com/), pass the `--preview` (or `-p`) flag to **rclip**. Graphics support is not detected; unsupported terminals may show missing images or escape-sequence text:
 
 ```bash
 rclip -p kitty
@@ -254,7 +254,7 @@ Run `rclip --help` (or `rclip -h`) to see this list in your terminal. The positi
 | `--subtract`, `--sub`, `-s`, `-` `QUERY` | A text query or a path/URL to an image file to subtract from the "original" query. Can be used multiple times. |
 | `--top`, `-t` `N` | Number of top results to display, or search results to load per batch with `--interactive`. Default: `10`, or `100` with `--interactive`; interactive maximum: `100`. |
 | `--interactive`, `-i` | Open the interactive terminal UI and enter text queries there. Does not accept a positional query or `--add`/`--subtract`. Mutually exclusive with `--preview` and `--filepath-only`. |
-| `--preview`, `-p` | Preview results in the terminal (supported in iTerm2, Konsole 22.04+, wezterm, Mintty, mlterm). Mutually exclusive with `--filepath-only`. |
+| `--preview`, `-p` | Preview results in the terminal (requires Kitty graphics). Mutually exclusive with `--filepath-only`. |
 | `--filepath-only`, `-f` | Output only filepaths, without scores or the header. Mutually exclusive with `--preview`. |
 | `--preview-height`, `-H` `PX` | Preview height in pixels. Default: `400`. |
 | `--no-indexing`, `--skip-index`, `--skip-indexing`, `-n` | Skip updating the index. Use only when no images were added, changed, or removed since the last run. |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ rclip "two parrots on a branch"
   macOS/Windows and experimental RAW (`arw`, `cr2`, `dng`).
 - **Fast incremental indexing** – only new and changed images are reprocessed on subsequent runs.
 - **Interactive terminal UI** – search a responsive thumbnail grid without leaving the terminal.
-- **Terminal previews** – view images inline in terminals supporting Kitty graphics.
+- **Terminal previews** – view images inline in terminals supporting Kitty graphics, such as Kitty, Ghostty, latest iTerm2, and Konsole.
 - **Cross-platform** – Linux, macOS (Apple Silicon), and Windows.
 
 ## Installation

--- a/rclip/tui/media.py
+++ b/rclip/tui/media.py
@@ -4,9 +4,7 @@ from PIL import Image as PILImage
 from PIL import ImageOps
 from textual.app import RenderResult
 from textual.geometry import Size
-from textual_image.renderable import Image as TerminalRenderable
 from textual_image.renderable import TGPImage as TGPRenderable
-from textual_image.widget import Image as TerminalImage
 from textual_image.widget import TGPImage
 
 from rclip.utils import helpers
@@ -53,4 +51,4 @@ class StableTGPImage(TGPImage, Renderable=TGPRenderable):
     self._rendered_size = None
 
 
-ImageWidget = StableTGPImage if TerminalRenderable is TGPRenderable else TerminalImage
+ImageWidget = StableTGPImage

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -305,8 +305,7 @@ def init_arg_parser() -> argparse.ArgumentParser:
     "-i",
     action="store_true",
     default=False,
-    help="opens the interactive terminal UI; enter text queries in the UI;"
-    " requires Kitty graphics with Unicode placeholders (e.g. Kitty, Ghostty)",
+    help="opens the interactive terminal UI; enter text queries in the UI",
   )
   display_mode_group.add_argument(
     "--preview",
@@ -314,7 +313,7 @@ def init_arg_parser() -> argparse.ArgumentParser:
     action="store_true",
     default=False,
     help="preview results in the terminal using Kitty graphics"
-    " (Kitty, Ghostty, iTerm2 3.6+, WezTerm, Konsole)",
+    " (e.g. Kitty, Ghostty, latest iTerm2, Konsole)",
   )
   display_mode_group.add_argument(
     "--filepath-only",

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -312,7 +312,7 @@ def init_arg_parser() -> argparse.ArgumentParser:
     "-p",
     action="store_true",
     default=False,
-    help="preview results in the terminal (supported in iTerm2, Konsole 22.04+, wezterm, Mintty, mlterm)",
+    help="preview results in the terminal (requires Kitty graphics)",
   )
   display_mode_group.add_argument(
     "--filepath-only",

--- a/rclip/utils/helpers.py
+++ b/rclip/utils/helpers.py
@@ -305,14 +305,16 @@ def init_arg_parser() -> argparse.ArgumentParser:
     "-i",
     action="store_true",
     default=False,
-    help="opens the interactive terminal UI; enter text queries in the UI",
+    help="opens the interactive terminal UI; enter text queries in the UI;"
+    " requires Kitty graphics with Unicode placeholders (e.g. Kitty, Ghostty)",
   )
   display_mode_group.add_argument(
     "--preview",
     "-p",
     action="store_true",
     default=False,
-    help="preview results in the terminal (requires Kitty graphics)",
+    help="preview results in the terminal using Kitty graphics"
+    " (Kitty, Ghostty, iTerm2 3.6+, WezTerm, Konsole)",
   )
   display_mode_group.add_argument(
     "--filepath-only",

--- a/rclip/utils/preview.py
+++ b/rclip/utils/preview.py
@@ -41,7 +41,7 @@ def preview(filepath: str, img_height_px: int):
     more = int(offset + 4096 < len(img_str))
     command = f"a=T,f=100,q=2,m={more}" if offset == 0 else f"q=2,m={more}"
     sequence = f"\033_G{command};{chunk}\033\\"
-    if os.getenv("TERM", "").startswith(("screen", "tmux")):
+    if os.getenv("TMUX") or os.getenv("TERM", "").startswith("tmux"):
       sequence = "\033Ptmux;" + sequence.replace("\033", "\033\033") + "\033\\"
     print(sequence, end="")
   print()

--- a/rclip/utils/preview.py
+++ b/rclip/utils/preview.py
@@ -1,7 +1,6 @@
 import base64
 from io import BytesIO
 import os
-import sys
 from PIL import Image
 
 from rclip.utils.helpers import read_image
@@ -25,30 +24,6 @@ def iterm_sequence(command: str) -> str:
   return f"{_get_start_sequence()}1337;{command}{_get_end_sequence()}"
 
 
-def _get_preview_dimensions(width_px: int, height_px: int) -> tuple[str, str]:
-  if sys.stdout.isatty() and os.name != "nt":
-    try:
-      import fcntl
-      import struct
-      import termios
-
-      rows, cols, terminal_width_px, terminal_height_px = struct.unpack(
-        "HHHH",
-        fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, struct.pack("HHHH", 0, 0, 0, 0)),
-      )
-      if rows > 0 and cols > 0 and terminal_width_px > 0 and terminal_height_px > 0:
-        cell_width_px = terminal_width_px / cols
-        cell_height_px = terminal_height_px / rows
-        return (
-          str(max(1, round(width_px / cell_width_px))),
-          str(max(1, round(height_px / cell_height_px))),
-        )
-    except OSError:
-      pass
-
-  return f"{width_px}px", f"{height_px}px"
-
-
 def preview(filepath: str, img_height_px: int):
   # preview images are displayed one at a time and the user opted into viewing them, so the
   # indexing memory cap doesn't apply; read as trusted like query images.
@@ -59,12 +34,14 @@ def preview(filepath: str, img_height_px: int):
       width_px, height_px = int(img_height_px * img.width / img.height), img_height_px
     img = img.resize((width_px, height_px), Image.LANCZOS)  # type: ignore
     buffer = BytesIO()
-    img.convert("RGB").save(buffer, format="JPEG")
-  img_bytes = buffer.getvalue()
-  img_str = base64.b64encode(img_bytes).decode("utf-8")
-  width, height = _get_preview_dimensions(width_px, height_px)
-  print(
-    iterm_sequence(
-      f"File=inline=1;size={len(img_bytes)};preserveAspectRatio=1;width={width};height={height}:{img_str}"
-    ),
-  )
+    img.convert("RGB").save(buffer, format="PNG")
+  img_str = base64.b64encode(buffer.getvalue()).decode("ascii")
+  for offset in range(0, len(img_str), 4096):
+    chunk = img_str[offset : offset + 4096]
+    more = int(offset + 4096 < len(img_str))
+    command = f"a=T,f=100,q=2,m={more}" if offset == 0 else f"q=2,m={more}"
+    sequence = f"\033_G{command};{chunk}\033\\"
+    if os.getenv("TERM", "").startswith(("screen", "tmux")):
+      sequence = "\033Ptmux;" + sequence.replace("\033", "\033\033") + "\033\\"
+    print(sequence, end="")
+  print()

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -30,20 +30,20 @@ def test_preview_transmits_resized_png_in_kitty_chunks(monkeypatch, capsys, term
 
   output = capsys.readouterr().out
   assert output.endswith("\n")
-  assert output.startswith("\033Ptmux;") == wrapped
-  if wrapped:
-    output = output.replace("\033Ptmux;", "").replace("\033\033", "\033").replace("\033\\\033\\", "\033\\")
-  commands = output.removesuffix("\n").split("\033\\")
+  prefix = "\033Ptmux;\033\033_G" if wrapped else "\033_G"
+  suffix = "\033\033\\\033\\" if wrapped else "\033\\"
+  commands = output.removesuffix("\n").split(suffix)
   assert commands.pop() == ""
   payload = ""
   for index, command in enumerate(commands):
-    header, chunk = command.split(";", 1)
+    assert command.startswith(prefix)
+    header, chunk = command.removeprefix(prefix).split(";", 1)
     more = int(index < len(commands) - 1)
-    expected = f"\033_Ga=T,f=100,q=2,m={more}" if index == 0 else f"\033_Gq=2,m={more}"
+    expected = f"a=T,f=100,q=2,m={more}" if index == 0 else f"q=2,m={more}"
     assert header == expected
     assert 0 < len(chunk) <= 4096
     payload += chunk
-  image = Image.open(BytesIO(base64.b64decode(payload)))
+  image = Image.open(BytesIO(base64.b64decode(payload, validate=True)))
   image.load()
   assert image.format == "PNG"
   assert image.size == (2 * min(height, 100), min(height, 100))

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -8,18 +8,30 @@ import pytest
 from rclip.utils import preview as preview_module
 
 
-@pytest.mark.parametrize("term", ["xterm-kitty", "xterm-256color", "tmux-256color"])
+@pytest.mark.parametrize(
+  "term,tmux,wrapped",
+  [
+    ("xterm-kitty", "", False),
+    ("xterm-256color", "", False),
+    ("screen-256color", "", False),
+    ("screen-256color", "/tmp/tmux-test/default,123,0", True),
+    ("xterm-256color", "/tmp/tmux-test/default,123,0", True),
+    ("tmux-256color", "", True),
+  ],
+)
 @pytest.mark.parametrize("height", [1, 50, 400])
-def test_preview_transmits_resized_png_in_kitty_chunks(monkeypatch, capsys, term, height):
+def test_preview_transmits_resized_png_in_kitty_chunks(monkeypatch, capsys, term, tmux, wrapped, height):
   original = Image.frombytes("RGB", (200, 100), Random(0).randbytes(60000))
   monkeypatch.setattr(preview_module, "read_image", lambda _filepath, **_kw: original.copy())
   monkeypatch.setenv("TERM", term)
+  monkeypatch.setenv("TMUX", tmux)
 
   preview_module.preview("cat.jpg", height)
 
   output = capsys.readouterr().out
   assert output.endswith("\n")
-  if term.startswith("tmux"):
+  assert output.startswith("\033Ptmux;") == wrapped
+  if wrapped:
     output = output.replace("\033Ptmux;", "").replace("\033\033", "\033").replace("\033\\\033\\", "\033\\")
   commands = output.removesuffix("\n").split("\033\\")
   assert commands.pop() == ""

--- a/tests/unit/test_preview.py
+++ b/tests/unit/test_preview.py
@@ -1,33 +1,39 @@
 import base64
 from io import BytesIO
+from random import Random
 
 from PIL import Image
+import pytest
 
 from rclip.utils import preview as preview_module
 
 
-def test_preview_uses_terminal_cell_dimensions_when_available(monkeypatch, capsys):
-  monkeypatch.setattr(preview_module, "read_image", lambda _filepath, **_kw: Image.new("RGB", (200, 100), "red"))
-  monkeypatch.setattr(preview_module, "_get_preview_dimensions", lambda _width, _height: ("10", "5"))
+@pytest.mark.parametrize("term", ["xterm-kitty", "xterm-256color", "tmux-256color"])
+@pytest.mark.parametrize("height", [1, 50, 400])
+def test_preview_transmits_resized_png_in_kitty_chunks(monkeypatch, capsys, term, height):
+  original = Image.frombytes("RGB", (200, 100), Random(0).randbytes(60000))
+  monkeypatch.setattr(preview_module, "read_image", lambda _filepath, **_kw: original.copy())
+  monkeypatch.setenv("TERM", term)
 
-  preview_module.preview("cat.jpg", 50)
+  preview_module.preview("cat.jpg", height)
 
-  output = capsys.readouterr().out.rstrip("\n")
-  start_sequence = preview_module._get_start_sequence()
-  end_sequence = preview_module._get_end_sequence()
-
-  assert ";width=10;height=5:" in output
-  assert output.startswith(f"{start_sequence}1337;File=inline=1;size=")
-  assert output.endswith(end_sequence)
-
-  metadata, encoded_image = output.split(":", 1)
-  assert metadata.startswith(f"{start_sequence}1337;File=inline=1;size=")
-
-  image = Image.open(BytesIO(base64.b64decode(encoded_image.removesuffix(end_sequence))))
-  assert image.size == (100, 50)
-
-
-def test_get_preview_dimensions_falls_back_to_pixels_when_tty_geometry_is_unavailable(monkeypatch):
-  monkeypatch.setattr(preview_module.sys.stdout, "isatty", lambda: False)
-
-  assert preview_module._get_preview_dimensions(120, 60) == ("120px", "60px")
+  output = capsys.readouterr().out
+  assert output.endswith("\n")
+  if term.startswith("tmux"):
+    output = output.replace("\033Ptmux;", "").replace("\033\033", "\033").replace("\033\\\033\\", "\033\\")
+  commands = output.removesuffix("\n").split("\033\\")
+  assert commands.pop() == ""
+  payload = ""
+  for index, command in enumerate(commands):
+    header, chunk = command.split(";", 1)
+    more = int(index < len(commands) - 1)
+    expected = f"\033_Ga=T,f=100,q=2,m={more}" if index == 0 else f"\033_Gq=2,m={more}"
+    assert header == expected
+    assert 0 < len(chunk) <= 4096
+    payload += chunk
+  image = Image.open(BytesIO(base64.b64decode(payload)))
+  image.load()
+  assert image.format == "PNG"
+  assert image.size == (2 * min(height, 100), min(height, 100))
+  if height == 400:
+    assert len(commands) > 1


### PR DESCRIPTION
## How does this PR impact the user?

- `--preview` now displays images using Kitty graphics instead of iTerm images; `--interactive` always uses Kitty graphics with Unicode placeholders.

## Description

- Send previews as chunked PNGs with suppressed replies, preserving height limits and tmux wrapping.
- Force the existing TGP widget and update terminal requirements. No new capability detection; dependency import behavior is unchanged.
- Validation: 177 unit tests, 34 end-to-end tests, Ruff, and type checks pass.

## Limitations

- Unsupported terminals have no image fallback and may display missing images or garbled output.
- Visual terminal testing is pending.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
