### PR TITLE
feat(tui): add centered filmstrip to TUI detail view

### DIFF
--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -122,7 +122,7 @@ class RclipApp(App[None]):
     self._search(query, self._search_generation, None)
 
   def _load_more(self) -> None:
-    if self._loading_more or (isinstance(self.screen, DetailScreen) and not self._pending_detail_advance):
+    if self._loading_more or (isinstance(self.screen, DetailScreen) and self._selected_index + 2 < len(self._cards())):
       return
     query = self.query_one("#search", Input).value.strip()
     if query:
@@ -215,6 +215,8 @@ class RclipApp(App[None]):
       self._pending_detail_advance = False
       if cards and isinstance(self.screen, DetailScreen):
         self._move_detail(1)
+    if append and isinstance(self.screen, DetailScreen):
+      self._update_detail()
     if not append:
       grid.scroll_home(animate=False)
       self._selected_index = 0
@@ -315,8 +317,19 @@ class RclipApp(App[None]):
     if index == self._selected_index:
       return
     self._selected_index = index
-    if isinstance(self.screen, DetailScreen):
-      self.screen.show_image(cards[index].result.filepath)
+    self._update_detail()
+
+  def _update_detail(self) -> None:
+    if not isinstance(self.screen, DetailScreen):
+      return
+    cards = self._cards()
+    filepath = cards[self._selected_index].result.filepath
+    if self.screen.filepath != filepath:
+      self.screen.show_image(filepath)
+    for thumbnail in self.screen.thumbnails:
+      index = self._selected_index + thumbnail.result_offset
+      thumbnail.show_image(cards[index].result.filepath if 0 <= index < len(cards) else None)
+    self._load_more()
 
   def action_move_left(self) -> None:
     if isinstance(self.screen, DetailScreen):
@@ -354,7 +367,8 @@ class RclipApp(App[None]):
 
   def action_view(self) -> None:
     if card := self._selected_card():
-      self.push_screen(DetailScreen(card.result.filepath))
+      self.push_screen(DetailScreen(card.result.filepath, self._move_detail))
+      self.call_after_refresh(self._update_detail)
 
   def action_go_back(self) -> None:
     self._pending_detail_advance = False

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -125,6 +125,7 @@ class RclipApp(App[None]):
   def _load_more(self) -> None:
     if self._loading_more or (
       isinstance(self.screen, DetailScreen)
+      and not self._pending_detail_advance
       and self._selected_index + len(self.screen.thumbnails) // 2 < len(self._cards())
     ):
       return
@@ -201,6 +202,8 @@ class RclipApp(App[None]):
       return
     grid = self.query_one(ResultsGrid)
     if not append:
+      if isinstance(self.screen, DetailScreen):
+        self.action_go_back()
       self.query_one("#gallery-path", Static).update("")
       await grid.remove_children()
       if not self._is_current_search(generation, query):
@@ -219,7 +222,7 @@ class RclipApp(App[None]):
       self._pending_detail_advance = False
       if cards and isinstance(self.screen, DetailScreen):
         self._move_detail(1)
-    if append and isinstance(self.screen, DetailScreen):
+    if append:
       self._update_detail()
     if not append:
       grid.scroll_home(animate=False)
@@ -374,7 +377,6 @@ class RclipApp(App[None]):
   def action_view(self) -> None:
     if card := self._selected_card():
       self.push_screen(DetailScreen(card.result.filepath, self._move_detail))
-      self.call_after_refresh(self._update_detail)
 
   def action_go_back(self) -> None:
     self._pending_detail_advance = False

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -324,15 +324,17 @@ class RclipApp(App[None]):
     self._update_detail()
 
   def _update_detail(self) -> None:
-    if not isinstance(self.screen, DetailScreen):
+    if not isinstance(self.screen, DetailScreen) or not self.screen.thumbnails:
       return
     cards = self._cards()
     filepath = cards[self._selected_index].result.filepath
     if self.screen.filepath != filepath:
       self.screen.show_image(filepath)
-    for thumbnail in self.screen.thumbnails:
-      index = self._selected_index + thumbnail.result_offset
-      thumbnail.show_image(cards[index].result.filepath if 0 <= index < len(cards) else None)
+    neighbors = len(self.screen.thumbnails) // 2
+    self.screen.show_thumbnails([
+      cards[index].result.filepath if 0 <= index < len(cards) else None
+      for index in range(self._selected_index - neighbors, self._selected_index + neighbors + 1)
+    ])
     self._load_more()
 
   def action_move_left(self) -> None:

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -13,6 +13,7 @@ from textual.worker import get_current_worker
 from textual.widgets import Input, Static
 
 from rclip.model import Model
+from rclip.tui.media import ImageWidget
 from rclip.tui.transfer import _is_remote_session
 from rclip.tui.transfer import copy_image_to_clipboard
 from rclip.tui.transfer import download_image
@@ -122,7 +123,10 @@ class RclipApp(App[None]):
     self._search(query, self._search_generation, None)
 
   def _load_more(self) -> None:
-    if self._loading_more or (isinstance(self.screen, DetailScreen) and self._selected_index + 2 < len(self._cards())):
+    if self._loading_more or (
+      isinstance(self.screen, DetailScreen)
+      and self._selected_index + len(self.screen.thumbnails) // 2 < len(self._cards())
+    ):
       return
     query = self.query_one("#search", Input).value.strip()
     if query:
@@ -375,6 +379,9 @@ class RclipApp(App[None]):
     if isinstance(self.screen, DetailScreen):
       selected_index = self._selected_index
       self.pop_screen()
+      # The terminal may have evicted gallery images while the detail view was active.
+      for image in self.query_one(ResultsGrid).query(ImageWidget):
+        image.refresh_image()
       cards = self._cards()
       if selected_index < len(cards):
         self.call_after_refresh(cards[selected_index].focus)

--- a/rclip/tui/app.tcss
+++ b/rclip/tui/app.tcss
@@ -92,10 +92,18 @@ ImageCard.preview-failed {
 .detail-thumbnail {
   width: 1fr;
   height: 100%;
-  padding: 0 1;
-  border: round transparent;
+  align: center middle;
 }
 
-.detail-thumbnail.selected {
+.detail-thumbnail-frame {
+  width: 85%;
+  height: 80%;
+  padding: 0 1;
+  border: round $border-blurred;
+}
+
+.detail-thumbnail.selected .detail-thumbnail-frame {
+  width: 100%;
+  height: 100%;
   border: heavy $accent;
 }

--- a/rclip/tui/app.tcss
+++ b/rclip/tui/app.tcss
@@ -84,3 +84,18 @@ ImageCard.preview-failed {
   text-align: center;
   text-overflow: ellipsis;
 }
+
+#detail-filmstrip {
+  height: 7;
+}
+
+.detail-thumbnail {
+  width: 1fr;
+  height: 100%;
+  padding: 0 1;
+  border: round transparent;
+}
+
+.detail-thumbnail.selected {
+  border: heavy $accent;
+}

--- a/rclip/tui/app.tcss
+++ b/rclip/tui/app.tcss
@@ -96,8 +96,8 @@ ImageCard.preview-failed {
 }
 
 .detail-thumbnail-frame {
-  width: 85%;
-  height: 80%;
+  width: 90%;
+  height: 90%;
   padding: 0 1;
   border: round $border-blurred;
 }

--- a/rclip/tui/app.tcss
+++ b/rclip/tui/app.tcss
@@ -86,7 +86,7 @@ ImageCard.preview-failed {
 }
 
 #detail-filmstrip {
-  height: 7;
+  height: 9;
 }
 
 .detail-thumbnail {
@@ -97,7 +97,7 @@ ImageCard.preview-failed {
 
 .detail-thumbnail-frame {
   width: 90%;
-  height: 90%;
+  height: 7;
   padding: 0 1;
   border: round $border-blurred;
 }
@@ -106,4 +106,9 @@ ImageCard.preview-failed {
   width: 100%;
   height: 100%;
   border: heavy $accent;
+}
+
+.detail-thumbnail-frame .thumbnail {
+  width: 100%;
+  height: 100%;
 }

--- a/rclip/tui/media.py
+++ b/rclip/tui/media.py
@@ -4,6 +4,7 @@ from PIL import Image as PILImage
 from PIL import ImageOps
 from textual.app import RenderResult
 from textual.geometry import Size
+from textual_image._pixeldata import PixelData
 from textual_image.renderable import TGPImage as TGPRenderable
 from textual_image.renderable.tgp import _send_tgp_message
 from textual_image.widget import TGPImage
@@ -65,3 +66,15 @@ class StableTGPImage(TGPImage, Renderable=_TGPRenderable):
 
 
 ImageWidget = StableTGPImage
+
+
+class _CenteredTGPRenderable(_TGPRenderable):
+  def _send_image_to_terminal(self, width: int, height: int) -> None:
+    self._image_data = PixelData(
+      ImageOps.pad(self._image_data.pil_image.convert("RGBA"), (width, height), color=(0, 0, 0, 0))
+    )
+    super()._send_image_to_terminal(width, height)
+
+
+class CenteredTGPImage(StableTGPImage, Renderable=_CenteredTGPRenderable):
+  """Center an aspect-preserving image in its full widget area, at pixel precision."""

--- a/rclip/tui/media.py
+++ b/rclip/tui/media.py
@@ -5,6 +5,7 @@ from PIL import ImageOps
 from textual.app import RenderResult
 from textual.geometry import Size
 from textual_image.renderable import TGPImage as TGPRenderable
+from textual_image.renderable.tgp import _send_tgp_message
 from textual_image.widget import TGPImage
 
 from rclip.utils import helpers
@@ -26,7 +27,15 @@ def prepare_image(filepath: str, size: tuple[int, int]) -> BytesIO:
   return prepared
 
 
-class StableTGPImage(TGPImage, Renderable=TGPRenderable):
+class _TGPRenderable(TGPRenderable):
+  def cleanup(self) -> None:
+    # textual-image 0.12.0 omits the deletion selector and confuses image IDs with numbers.
+    if self.terminal_image_id is not None:
+      _send_tgp_message(a="d", d="I", i=self.terminal_image_id, q=2)
+      self.terminal_image_id = None
+
+
+class StableTGPImage(TGPImage, Renderable=_TGPRenderable):
   """Keep a Kitty image alive until its source or rendered size changes."""
 
   _rendered_size: Size | None = None
@@ -40,6 +49,10 @@ class StableTGPImage(TGPImage, Renderable=TGPRenderable):
       self._renderable = self._Renderable(self.image, *self._get_styled_size())
     self._rendered_size = self.content_size
     return self._renderable
+
+  def refresh_image(self) -> None:
+    self._discard_renderable()
+    self.refresh()
 
   def on_unmount(self) -> None:
     self._discard_renderable()

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -7,7 +7,7 @@ from typing import Callable, Sequence, cast
 
 from textual import events, work
 from textual.app import ComposeResult
-from textual.containers import CenterMiddle, ItemGrid
+from textual.containers import CenterMiddle, Horizontal, ItemGrid
 from textual.screen import Screen
 from textual.worker import get_current_worker
 from textual.widgets import Label, Static
@@ -123,15 +123,61 @@ class ResultsGrid(ItemGrid):
     self.call_after_refresh(self.update_visible)
 
 
+class DetailThumbnail(Static):
+  def __init__(self, offset: int, browse: Callable[[int], None]) -> None:
+    super().__init__(classes="detail-thumbnail selected" if offset == 0 else "detail-thumbnail")
+    self.result_offset = offset
+    self.browse = browse
+    self.filepath: str | None = None
+    self._image = ImageWidget(classes="thumbnail")
+
+  def compose(self) -> ComposeResult:
+    with CenterMiddle():
+      yield self._image
+
+  def show_image(self, filepath: str | None) -> None:
+    if filepath == self.filepath:
+      return
+    self.filepath = filepath
+    self._image.image = None
+    self._load_preview()
+
+  @work(thread=True, exclusive=True, exit_on_error=False)
+  def _load_preview(self) -> None:
+    filepath = self.filepath
+    if filepath is None:
+      return
+    with _IMAGE_DECODES:
+      if get_current_worker().is_cancelled:
+        return
+      try:
+        preview = prepare_image(filepath, PREVIEW_SIZE)
+      except Exception:
+        return
+      self.app.call_from_thread(self._show_preview, filepath, preview)
+
+  def _show_preview(self, filepath: str, preview: BytesIO) -> None:
+    if self.is_attached and filepath == self.filepath:
+      self._image.image = preview
+
+  def on_click(self, event: events.Click) -> None:
+    event.stop()
+    if event.button == 1 and event.chain == 1 and self.filepath is not None:
+      self.browse(self.result_offset)
+
+
 class DetailScreen(Screen[None]):
-  def __init__(self, filepath: str) -> None:
+  def __init__(self, filepath: str, browse: Callable[[int], None]) -> None:
     super().__init__()
     self.filepath = filepath
     self._image = ImageWidget(classes="detail-image")
+    self.thumbnails = [DetailThumbnail(offset, browse) for offset in range(-2, 3)]
 
   def compose(self) -> ComposeResult:
     with CenterMiddle(id="detail-frame"):
       yield self._image
+    with Horizontal(id="detail-filmstrip"):
+      yield from self.thumbnails
     yield Static("Loading higher-resolution image…", id="detail-status", markup=False)
     yield Static(self.filepath, id="detail-path", markup=False)
     yield Static(

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -12,6 +12,7 @@ from textual.screen import Screen
 from textual.worker import get_current_worker
 from textual.widgets import Label, Static
 
+from rclip.tui.media import CenteredTGPImage
 from rclip.tui.media import ImageWidget
 from rclip.tui.media import prepare_image
 
@@ -130,7 +131,7 @@ class DetailThumbnail(Static):
     self.result_offset = offset
     self.browse = browse
     self.filepath: str | None = None
-    self._image = ImageWidget(classes="thumbnail")
+    self._image = CenteredTGPImage(classes="thumbnail")
 
   def compose(self) -> ComposeResult:
     with CenterMiddle(classes="detail-thumbnail-frame"):

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -205,6 +205,21 @@ class DetailScreen(Screen[None]):
     if isinstance(self.app, RclipApp):
       self.app._update_detail()
 
+  def show_thumbnails(self, filepaths: list[str | None]) -> None:
+    retained = {
+      thumbnail.filepath: thumbnail
+      for thumbnail in self.thumbnails
+      if thumbnail.filepath is not None and thumbnail.filepath in filepaths
+    }
+    unused = iter(thumbnail for thumbnail in self.thumbnails if thumbnail not in retained.values())
+    self.thumbnails = [retained[filepath] if filepath in retained else next(unused) for filepath in filepaths]
+    filmstrip = self.query_one("#detail-filmstrip", Horizontal)
+    for index, (thumbnail, filepath) in enumerate(zip(self.thumbnails, filepaths)):
+      thumbnail.result_offset = index - len(filepaths) // 2
+      thumbnail.set_class(thumbnail.result_offset == 0, "selected")
+      thumbnail.show_image(filepath)
+      filmstrip.move_child(thumbnail, before=index)
+
   def show_image(self, filepath: str) -> None:
     self.filepath = filepath
     self._image.display = False

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -126,16 +126,18 @@ class ResultsGrid(ItemGrid):
 class DetailThumbnail(Static):
   def __init__(self, offset: int, browse: Callable[[int], None]) -> None:
     super().__init__(classes="detail-thumbnail selected" if offset == 0 else "detail-thumbnail")
+    self.visible = False
     self.result_offset = offset
     self.browse = browse
     self.filepath: str | None = None
     self._image = ImageWidget(classes="thumbnail")
 
   def compose(self) -> ComposeResult:
-    with CenterMiddle():
+    with CenterMiddle(classes="detail-thumbnail-frame"):
       yield self._image
 
   def show_image(self, filepath: str | None) -> None:
+    self.visible = filepath is not None
     if filepath == self.filepath:
       return
     self.filepath = filepath
@@ -171,14 +173,15 @@ class DetailScreen(Screen[None]):
     super().__init__()
     self.filepath = filepath
     self._image = ImageWidget(classes="detail-image")
-    self.thumbnails = [DetailThumbnail(offset, browse) for offset in range(-2, 3)]
+    self._image.display = False
+    self._browse = browse
+    self.thumbnails: list[DetailThumbnail] = []
 
   def compose(self) -> ComposeResult:
     with CenterMiddle(id="detail-frame"):
       yield self._image
-    with Horizontal(id="detail-filmstrip"):
-      yield from self.thumbnails
-    yield Static("Loading higher-resolution image…", id="detail-status", markup=False)
+      yield Static("Loading higher-resolution image…", id="detail-status", markup=False)
+    yield Horizontal(id="detail-filmstrip")
     yield Static(self.filepath, id="detail-path", markup=False)
     yield Static(
       "h/l/Arrows Browse   Esc/Double-click Back   y Copy   Y Copy path   d Download   q/Ctrl+C Quit",
@@ -189,8 +192,22 @@ class DetailScreen(Screen[None]):
   def on_mount(self) -> None:
     self._load_detail()
 
+  async def on_resize(self, event: events.Resize) -> None:
+    from rclip.tui.app import RclipApp
+
+    neighbors = max(0, (event.size.width // 16 - 1) // 2)
+    if len(self.thumbnails) == neighbors * 2 + 1:
+      return
+    filmstrip = self.query_one("#detail-filmstrip", Horizontal)
+    await filmstrip.remove_children()
+    self.thumbnails = [DetailThumbnail(offset, self._browse) for offset in range(-neighbors, neighbors + 1)]
+    await filmstrip.mount(*self.thumbnails)
+    if isinstance(self.app, RclipApp):
+      self.app._update_detail()
+
   def show_image(self, filepath: str) -> None:
     self.filepath = filepath
+    self._image.display = False
     self._image.image = None
     status = self.query_one("#detail-status", Static)
     status.update("Loading higher-resolution image…")
@@ -222,6 +239,7 @@ class DetailScreen(Screen[None]):
     if not self.is_attached or filepath != self.filepath:
       return
     self._image.image = detail
+    self._image.display = True
     self.query_one("#detail-status", Static).display = False
 
   def _show_error(self, filepath: str, message: str) -> None:

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -571,6 +571,48 @@ def test_detail_loading_and_error_keep_layout_stable(tmp_path: Path, monkeypatch
   asyncio.run(run())
 
 
+def test_filmstrip_reuses_loaded_neighbors_while_new_thumbnail_loads(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  paths = [str(make_image(tmp_path / f"image-{index}.jpg")) for index in range(7)]
+  app = RclipApp(FakeRclip([RClip.SearchResult(path, 1) for path in paths]), str(tmp_path))
+  previews: list[str] = []
+  release = Event()
+
+  def slow_prepare(filepath: str, size: tuple[int, int]):
+    if size == (640, 480):
+      previews.append(filepath)
+      assert release.wait(5)
+    return prepare_image(filepath, size)
+
+  async def run() -> None:
+    async with app.run_test(size=(100, 40)) as pilot:
+      await app.workers.wait_for_complete()
+      await pilot.press("down", "enter", "right", "right")
+      await app.workers.wait_for_complete()
+      screen = app.screen
+      assert isinstance(screen, DetailScreen)
+      loaded = {thumbnail.filepath: (thumbnail, thumbnail._image.image) for thumbnail in screen.thumbnails}
+      monkeypatch.setattr("rclip.tui.views.prepare_image", slow_prepare)
+      try:
+        app.action_move_right()
+        assert [thumbnail.filepath for thumbnail in screen.thumbnails] == paths[1:6]
+        for thumbnail in screen.thumbnails[:-1]:
+          previous, image = loaded[thumbnail.filepath]
+          assert thumbnail is previous
+          assert thumbnail._image.image is image
+          assert image is not None
+        assert screen.thumbnails[-1]._image.image is None
+        await pilot.pause()
+        assert previews == [paths[5]]
+      finally:
+        release.set()
+      await app.workers.wait_for_complete()
+      assert all(thumbnail._image.image is not None for thumbnail in screen.thumbnails)
+
+  asyncio.run(run())
+
+
 def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> None:
   paths = [str(make_image(tmp_path / f"image-{index}.jpg")) for index in range(5)]
   app = RclipApp(FakeRclip([RClip.SearchResult(path, 1) for path in paths]), str(tmp_path))
@@ -597,8 +639,8 @@ def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> Non
         assert thumbnail._image.content_size.width < selected_size.width
         assert thumbnail._image.content_size.height < selected_size.height
         frame = thumbnail.query_one(".detail-thumbnail-frame").region
-        assert frame.width < selected_frame.width
-        assert frame.height < selected_frame.height
+        assert 0 < selected_frame.width - frame.width <= 2
+        assert selected_frame.height - frame.height == 1
       await pilot.press("right", "right")
       await app.workers.wait_for_complete()
       assert [thumbnail.filepath for thumbnail in screen.thumbnails] == [*paths[2:], None, None]

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -531,6 +531,10 @@ def test_gallery_resends_thumbnails_after_detail_browsing(tmp_path: Path, monkey
       await app.workers.wait_for_complete()
       await pilot.pause()
       cards = app.query_one(ResultsGrid).cards
+      for card in cards:
+        card.load_preview()
+      await app.workers.wait_for_complete()
+      await pilot.pause()
       before = [card._image.render() for card in cards]
       assert all(isinstance(renderable, TGPRenderable) for renderable in before)
       await pilot.press("down", "enter", "right", "right", "left", "escape")
@@ -725,15 +729,15 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
         ]
         async with asyncio.timeout(0.25):
           while app.screen.filepath != path or [thumbnail.filepath for thumbnail in app.screen.thumbnails] != expected:
-            await asyncio.sleep(0.01)
+            await pilot.pause(0.01)
       await pilot.press("right")
       assert app.screen.filepath == paths[-1]
       await pilot.press("left")
       assert app.screen.filepath == paths[-2]
       await pilot.press("escape")
-      await pilot.pause()
-      assert isinstance(app.focused, ImageCard)
-      assert app.focused.result.filepath == paths[-2]
+      async with asyncio.timeout(0.25):
+        while app.focused is not app.query_one(ResultsGrid).cards[-2]:
+          await pilot.pause(0.01)
       assert [card.result.filepath for card in app.query(ImageCard)] == paths
 
   asyncio.run(run())

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -479,6 +479,46 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
   asyncio.run(run())
 
 
+def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> None:
+  paths = [str(make_image(tmp_path / f"image-{index}.jpg")) for index in range(5)]
+  app = RclipApp(FakeRclip([RClip.SearchResult(path, 1) for path in paths]), str(tmp_path))
+
+  async def run() -> None:
+    async with app.run_test(size=(100, 40)) as pilot:
+      await app.workers.wait_for_complete()
+      await pilot.press("down", "enter")
+      await app.workers.wait_for_complete()
+      screen = app.screen
+      assert isinstance(screen, DetailScreen)
+      assert [thumbnail.filepath for thumbnail in screen.thumbnails] == [None, None, *paths[:3]]
+      assert all(thumbnail._image.image is not None for thumbnail in screen.thumbnails[2:])
+      await pilot.click(screen.thumbnails[0])
+      assert screen.filepath == paths[0]
+      await pilot.click(screen.thumbnails[4])
+      await app.workers.wait_for_complete()
+      assert screen.filepath == paths[2]
+      assert [thumbnail.filepath for thumbnail in screen.thumbnails] == paths
+      await pilot.press("right", "right")
+      await app.workers.wait_for_complete()
+      assert [thumbnail.filepath for thumbnail in screen.thumbnails] == [*paths[2:], None, None]
+      assert all(thumbnail._image.image is None for thumbnail in screen.thumbnails[3:])
+      for width, height in [(100, 40), (81, 24), (40, 16)]:
+        await pilot.resize_terminal(width, height)
+        await pilot.pause()
+        center = screen.thumbnails[2].region
+        assert abs(center.x * 2 + center.width - width) <= 1
+        assert screen.query_one("#detail-frame").region.height > 0
+      await pilot.press("h", "l", "left")
+      await app.workers.wait_for_complete()
+      assert screen.filepath == paths[3]
+      assert screen.thumbnails[2].filepath == paths[3]
+      await pilot.press("escape")
+      assert isinstance(app.focused, ImageCard)
+      assert app.focused.result.filepath == paths[3]
+
+  asyncio.run(run())
+
+
 @pytest.mark.parametrize("query", ["", "cat"])
 def test_detail_navigation_loads_more_results(tmp_path: Path, query: str) -> None:
   paths = [str(tmp_path / f"image-{index}.jpg") for index in range(51)]
@@ -496,15 +536,13 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str) -> Non
       await pilot.press("down", "enter")
       assert isinstance(app.screen, DetailScreen)
       for index, path in enumerate(paths[1:], 1):
-        if index % 25 == 0:
-          # Repeated input before the batch arrives must still advance exactly once.
-          app.action_move_right()
-          app.action_move_right()
-        else:
-          await pilot.press("right")
+        await pilot.press("right")
         await app.workers.wait_for_complete()
         await pilot.pause(0.1)
         assert app.screen.filepath == path
+        assert [thumbnail.filepath for thumbnail in app.screen.thumbnails] == [
+          paths[neighbor] if 0 <= neighbor < len(paths) else None for neighbor in range(index - 2, index + 3)
+        ]
       await pilot.press("right")
       assert app.screen.filepath == paths[-1]
       await pilot.press("left")
@@ -520,8 +558,8 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str) -> Non
   assert rclip.searches == ([(query, str(tmp_path), None, [], [])] if query else [])
 
 
-@pytest.mark.parametrize("action", ["left", "escape"])
-def test_detail_navigation_cancels_pending_advance(
+@pytest.mark.parametrize("action", ["left", "right", "escape"])
+def test_detail_navigation_handles_pending_advance(
   tmp_path: Path, monkeypatch: pytest.MonkeyPatch, action: str
 ) -> None:
   paths = [str(tmp_path / f"image-{index}.jpg") for index in range(26)]
@@ -554,9 +592,9 @@ def test_detail_navigation_cancels_pending_advance(
       await app.workers.wait_for_complete()
       await pilot.pause()
       assert len(app.query(ImageCard)) == 26
-      if action == "left":
+      if action != "escape":
         assert isinstance(app.screen, DetailScreen)
-        assert app.screen.filepath == paths[23]
+        assert app.screen.filepath == paths[23 if action == "left" else 25]
       else:
         assert not isinstance(app.screen, DetailScreen)
         assert isinstance(app.focused, ImageCard)
@@ -839,7 +877,7 @@ def test_empty_browse_retries_loading_more_after_failure(
 
       grid = app.query_one(ResultsGrid)
       if detail:
-        await pilot.press("down", "enter", *(["right"] * 25))
+        await pilot.press("down", "enter", *(["right"] * 23))
       else:
         grid.scroll_end(animate=False)
       await app.workers.wait_for_complete()
@@ -849,7 +887,7 @@ def test_empty_browse_retries_loading_more_after_failure(
 
       if detail:
         assert isinstance(app.screen, DetailScreen)
-        assert app.screen.filepath == str(paths[24])
+        assert app.screen.filepath == str(paths[23])
         await pilot.press("right")
       else:
         grid.scroll_home(animate=False)
@@ -860,7 +898,7 @@ def test_empty_browse_retries_loading_more_after_failure(
       assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths]
       if detail:
         assert isinstance(app.screen, DetailScreen)
-        assert app.screen.filepath == str(paths[25])
+        assert app.screen.filepath == str(paths[24])
 
   asyncio.run(run())
 

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -11,6 +11,8 @@ from threading import Event, Lock
 from types import SimpleNamespace
 
 from PIL import Image
+from rich.console import Console
+from textual_image.renderable import TGPImage as TGPRenderable
 import pytest
 from textual.geometry import Size
 from textual.widgets import Input, Static
@@ -194,6 +196,23 @@ def test_kitty_image_reuses_its_renderable_until_its_size_changes(
 
   image.on_unmount()
   assert second.cleaned
+
+
+def test_kitty_image_cleanup_deletes_only_its_own_image(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+  output = StringIO()
+  monkeypatch.setattr(sys, "__stdout__", output)
+  image = StableTGPImage(make_image(tmp_path / "image.jpg"))
+  renderable = image.render()
+  assert isinstance(renderable, TGPRenderable)
+  Console(file=StringIO(), width=20).print(renderable)
+  image_id = renderable.terminal_image_id
+  assert image_id is not None
+  output.seek(0)
+  output.truncate()
+  image.on_unmount()
+  assert output.getvalue() == f"\x1b_Ga=d,d=I,i={image_id},q=2\x1b\\"
+  image.on_unmount()
+  assert output.getvalue() == f"\x1b_Ga=d,d=I,i={image_id},q=2\x1b\\"
 
 
 def test_copy_image_keeps_common_formats_and_converts_others(
@@ -479,6 +498,79 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
   asyncio.run(run())
 
 
+def test_gallery_resends_thumbnails_after_detail_browsing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+  monkeypatch.setattr(sys, "__stdout__", StringIO())
+  paths = [make_image(tmp_path / f"image-{index}.jpg") for index in range(6)]
+  app = RclipApp(FakeRclip([RClip.SearchResult(str(path), 1) for path in paths]), str(tmp_path))
+
+  async def run() -> None:
+    async with app.run_test(size=(100, 40)) as pilot:
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+      cards = app.query_one(ResultsGrid).cards
+      before = [card._image.render() for card in cards]
+      assert all(isinstance(renderable, TGPRenderable) for renderable in before)
+      await pilot.press("down", "enter", "right", "right", "left", "escape")
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+      for card, previous in zip(cards, before):
+        assert isinstance(previous, TGPRenderable)
+        assert previous.terminal_image_id is None
+        current = card._image.render()
+        assert isinstance(current, TGPRenderable)
+        assert current is not previous
+        assert current.terminal_image_id is not None
+      await pilot.press("right", "left")
+      assert all(card._image.image is not None for card in cards)
+
+  asyncio.run(run())
+
+
+def test_detail_loading_and_error_keep_layout_stable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+  path = make_image(tmp_path / "image.jpg")
+  missing = tmp_path / "missing.jpg"
+  app = RclipApp(FakeRclip([RClip.SearchResult(str(item), 1) for item in [path, missing]]), str(tmp_path))
+  started = Event()
+  release = Event()
+
+  def slow_prepare(filepath: str, size: tuple[int, int]):
+    if size == (1920, 1920):
+      started.set()
+      assert release.wait(5)
+    return prepare_image(filepath, size)
+
+  monkeypatch.setattr("rclip.tui.views.prepare_image", slow_prepare)
+
+  async def run() -> None:
+    async with app.run_test(size=(100, 40)) as pilot:
+      try:
+        await app.workers.wait_for_complete()
+        await pilot.press("down", "enter")
+        assert await asyncio.to_thread(started.wait, 1)
+        screen = app.screen
+        assert isinstance(screen, DetailScreen)
+        status = screen.query_one("#detail-status", Static)
+        frame = screen.query_one("#detail-frame")
+        filmstrip = screen.query_one("#detail-filmstrip")
+        regions = frame.region, filmstrip.region
+        assert status.display and not screen._image.display
+        assert frame.region.contains_region(status.region)
+      finally:
+        release.set()
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+      assert not status.display and screen._image.display
+      assert (frame.region, filmstrip.region) == regions
+      await pilot.press("right")
+      await app.workers.wait_for_complete()
+      await pilot.pause()
+      assert status.display and not screen._image.display
+      assert (frame.region, filmstrip.region) == regions
+      assert frame.region.contains_region(status.region)
+
+  asyncio.run(run())
+
+
 def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> None:
   paths = [str(make_image(tmp_path / f"image-{index}.jpg")) for index in range(5)]
   app = RclipApp(FakeRclip([RClip.SearchResult(path, 1) for path in paths]), str(tmp_path))
@@ -492,26 +584,41 @@ def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> Non
       assert isinstance(screen, DetailScreen)
       assert [thumbnail.filepath for thumbnail in screen.thumbnails] == [None, None, *paths[:3]]
       assert all(thumbnail._image.image is not None for thumbnail in screen.thumbnails[2:])
-      await pilot.click(screen.thumbnails[0])
-      assert screen.filepath == paths[0]
+      assert all(not thumbnail.visible for thumbnail in screen.thumbnails[:2])
+      assert all(thumbnail.visible for thumbnail in screen.thumbnails[2:])
       await pilot.click(screen.thumbnails[4])
       await app.workers.wait_for_complete()
       assert screen.filepath == paths[2]
       assert [thumbnail.filepath for thumbnail in screen.thumbnails] == paths
+      await pilot.pause()
+      selected_size = screen.thumbnails[2]._image.content_size
+      selected_frame = screen.thumbnails[2].query_one(".detail-thumbnail-frame").region
+      for thumbnail in [*screen.thumbnails[:2], *screen.thumbnails[3:]]:
+        assert thumbnail._image.content_size.width < selected_size.width
+        assert thumbnail._image.content_size.height < selected_size.height
+        frame = thumbnail.query_one(".detail-thumbnail-frame").region
+        assert frame.width < selected_frame.width
+        assert frame.height < selected_frame.height
       await pilot.press("right", "right")
       await app.workers.wait_for_complete()
       assert [thumbnail.filepath for thumbnail in screen.thumbnails] == [*paths[2:], None, None]
       assert all(thumbnail._image.image is None for thumbnail in screen.thumbnails[3:])
-      for width, height in [(100, 40), (81, 24), (40, 16)]:
+      assert all(not thumbnail.visible for thumbnail in screen.thumbnails[3:])
+      for width, height, count in [(100, 40, 5), (81, 24, 5), (40, 16, 1), (160, 40, 9)]:
         await pilot.resize_terminal(width, height)
         await pilot.pause()
-        center = screen.thumbnails[2].region
+        assert len(screen.thumbnails) == count
+        assert [thumbnail.filepath for thumbnail in screen.thumbnails] == [
+          paths[index] if 0 <= index < len(paths) else None
+          for index in range(4 - count // 2, 5 + count // 2)
+        ]
+        center = screen.thumbnails[count // 2].region
         assert abs(center.x * 2 + center.width - width) <= 1
         assert screen.query_one("#detail-frame").region.height > 0
       await pilot.press("h", "l", "left")
       await app.workers.wait_for_complete()
       assert screen.filepath == paths[3]
-      assert screen.thumbnails[2].filepath == paths[3]
+      assert screen.thumbnails[len(screen.thumbnails) // 2].filepath == paths[3]
       await pilot.press("escape")
       assert isinstance(app.focused, ImageCard)
       assert app.focused.result.filepath == paths[3]
@@ -537,11 +644,15 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str) -> Non
       assert isinstance(app.screen, DetailScreen)
       for index, path in enumerate(paths[1:], 1):
         await pilot.press("right")
+        if index == 22:
+          await pilot.resize_terminal(160, 24)
         await app.workers.wait_for_complete()
         await pilot.pause(0.1)
         assert app.screen.filepath == path
+        neighbors = len(app.screen.thumbnails) // 2
         assert [thumbnail.filepath for thumbnail in app.screen.thumbnails] == [
-          paths[neighbor] if 0 <= neighbor < len(paths) else None for neighbor in range(index - 2, index + 3)
+          paths[neighbor] if 0 <= neighbor < len(paths) else None
+          for neighbor in range(index - neighbors, index + neighbors + 1)
         ]
       await pilot.press("right")
       assert app.screen.filepath == paths[-1]

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -641,6 +641,11 @@ def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> Non
         frame = thumbnail.query_one(".detail-thumbnail-frame").region
         assert 0 < selected_frame.width - frame.width <= 2
         assert selected_frame.height - frame.height == 1
+        slot = thumbnail.region
+        preview = thumbnail._image.region
+        assert abs(frame.y * 2 + frame.height - (slot.y * 2 + slot.height)) <= 1
+        assert abs(preview.x * 2 + preview.width - (frame.x * 2 + frame.width)) <= 1
+        assert abs(preview.y * 2 + preview.height - (frame.y * 2 + frame.height)) <= 1
       await pilot.press("right", "right")
       await app.workers.wait_for_complete()
       assert [thumbnail.filepath for thumbnail in screen.thumbnails] == [*paths[2:], None, None]

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -724,6 +724,7 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
         if width == 80 and index == 22:
           await pilot.resize_terminal(160, 24)
         await app.workers.wait_for_complete()
+        await pilot.pause()
         neighbors = (4 if index >= 22 else 2) if width == 80 else 0
         expected = [
           paths[neighbor] if 0 <= neighbor < len(paths) else None
@@ -737,6 +738,7 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
       await pilot.press("left")
       assert app.screen.filepath == paths[-2]
       await pilot.press("escape")
+      await pilot.pause()
       async with asyncio.timeout(0.25):
         while app.focused is not app.query_one(ResultsGrid).cards[-2]:
           await pilot.pause(0.01)

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -717,13 +717,14 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str) -> Non
         if index == 22:
           await pilot.resize_terminal(160, 24)
         await app.workers.wait_for_complete()
-        await pilot.pause(0.1)
-        assert app.screen.filepath == path
-        neighbors = len(app.screen.thumbnails) // 2
-        assert [thumbnail.filepath for thumbnail in app.screen.thumbnails] == [
+        neighbors = 4 if index >= 22 else 2
+        expected = [
           paths[neighbor] if 0 <= neighbor < len(paths) else None
           for neighbor in range(index - neighbors, index + neighbors + 1)
         ]
+        async with asyncio.timeout(0.25):
+          while app.screen.filepath != path or [thumbnail.filepath for thumbnail in app.screen.thumbnails] != expected:
+            await asyncio.sleep(0.01)
       await pilot.press("right")
       assert app.screen.filepath == paths[-1]
       await pilot.press("left")

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -1,7 +1,7 @@
 import asyncio
 import base64
 from contextlib import nullcontext
-from io import StringIO
+from io import BytesIO, StringIO
 import os
 from pathlib import Path
 import re
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 from PIL import Image
 from rich.console import Console
 from textual_image.renderable import TGPImage as TGPRenderable
+from textual_image._terminal import CellSize
 import pytest
 from textual.geometry import Size
 from textual.widgets import Input, Static
@@ -21,6 +22,7 @@ from rclip import main as main_module
 from rclip.main import RClip
 from rclip.tui.app import RclipApp
 from rclip.tui.app import _display_directory
+from rclip.tui.media import CenteredTGPImage
 from rclip.tui.media import StableTGPImage
 from rclip.tui.media import prepare_image
 from rclip.tui.transfer import TransferError
@@ -196,6 +198,27 @@ def test_kitty_image_reuses_its_renderable_until_its_size_changes(
 
   image.on_unmount()
   assert second.cleaned
+
+
+@pytest.mark.parametrize("size", [(1200, 800), (800, 1200), (800, 800)])
+def test_strip_preview_pixels_are_centered_and_keep_aspect_ratio(
+  monkeypatch: pytest.MonkeyPatch, size: tuple[int, int]
+) -> None:
+  output = StringIO()
+  monkeypatch.setattr(sys, "__stdout__", output)
+  monkeypatch.setattr("textual_image.renderable.tgp.get_cell_size", lambda: CellSize(17, 33))
+  renderable = CenteredTGPImage._Renderable(Image.new("RGB", size, "red"), 13, 5)
+  Console(file=StringIO(), width=13).print(renderable)
+  chunks = re.findall(r"\x1b_G[^;]*;([A-Za-z0-9+/=]+)\x1b\\", output.getvalue())
+  with Image.open(BytesIO(base64.b64decode("".join(chunks)))) as image:
+    assert image.size == (221, 165)
+    bounds = image.getbbox()
+    assert bounds is not None
+    left, top, right, bottom = bounds
+    assert abs(left - (image.width - right)) <= 1
+    assert abs(top - (image.height - bottom)) <= 1
+    assert abs((right - left) - (bottom - top) * size[0] / size[1]) <= 1
+    assert left > 0 or top > 0
 
 
 def test_kitty_image_cleanup_deletes_only_its_own_image(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -640,10 +663,10 @@ def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> Non
         assert thumbnail._image.content_size.height < selected_size.height
         frame = thumbnail.query_one(".detail-thumbnail-frame").region
         assert 0 < selected_frame.width - frame.width <= 2
-        assert selected_frame.height - frame.height == 1
+        assert selected_frame.height - frame.height == 2
         slot = thumbnail.region
         preview = thumbnail._image.region
-        assert abs(frame.y * 2 + frame.height - (slot.y * 2 + slot.height)) <= 1
+        assert frame.y - slot.y == slot.bottom - frame.bottom == 1
         assert abs(preview.x * 2 + preview.width - (frame.x * 2 + frame.width)) <= 1
         assert abs(preview.y * 2 + preview.height - (frame.y * 2 + frame.height)) <= 1
       await pilot.press("right", "right")

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -1062,8 +1062,9 @@ def test_empty_browse_retries_loading_more_after_failure(
         await pilot.press("down", "enter", *(["right"] * 23))
       else:
         grid.scroll_end(animate=False)
-      await app.workers.wait_for_complete()
-      await pilot.pause()
+      async with asyncio.timeout(0.25):
+        while not notifications:
+          await asyncio.sleep(0.01)
       assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths[:25]]
       assert notifications == [("page failed", "Unable to load more images")]
 
@@ -1075,9 +1076,10 @@ def test_empty_browse_retries_loading_more_after_failure(
         grid.scroll_home(animate=False)
         await pilot.pause()
         grid.scroll_end(animate=False)
-      await app.workers.wait_for_complete()
-      await pilot.pause()
-      assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths]
+      expected = [str(path) for path in paths]
+      async with asyncio.timeout(0.25):
+        while [card.result.filepath for card in app.query(ImageCard)] != expected:
+          await asyncio.sleep(0.01)
       if detail:
         assert isinstance(app.screen, DetailScreen)
         assert app.screen.filepath == str(paths[24])

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -711,7 +711,9 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
     async with app.run_test(size=(width, 24)) as pilot:
       await app.workers.wait_for_complete()
       if query:
-        await pilot.press(*query, "enter")
+        with app.prevent(Input.Changed):
+          app.query_one(Input).value = query
+        await pilot.press("enter")
         await app.workers.wait_for_complete()
       await pilot.pause()
       assert len(app.query(ImageCard)) == 25

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -697,13 +697,14 @@ def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> Non
 
 
 @pytest.mark.parametrize("query", ["", "cat"])
-def test_detail_navigation_loads_more_results(tmp_path: Path, query: str) -> None:
+@pytest.mark.parametrize("width", [40, 80])
+def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width: int) -> None:
   paths = [str(tmp_path / f"image-{index}.jpg") for index in range(51)]
   rclip = FakeRclip([RClip.SearchResult(path, 1) for path in paths])
   app = RclipApp(rclip, str(tmp_path), top_k=25)
 
   async def run() -> None:
-    async with app.run_test(size=(80, 24)) as pilot:
+    async with app.run_test(size=(width, 24)) as pilot:
       await app.workers.wait_for_complete()
       if query:
         await pilot.press(*query, "enter")
@@ -714,10 +715,10 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str) -> Non
       assert isinstance(app.screen, DetailScreen)
       for index, path in enumerate(paths[1:], 1):
         await pilot.press("right")
-        if index == 22:
+        if width == 80 and index == 22:
           await pilot.resize_terminal(160, 24)
         await app.workers.wait_for_complete()
-        neighbors = 4 if index >= 22 else 2
+        neighbors = (4 if index >= 22 else 2) if width == 80 else 0
         expected = [
           paths[neighbor] if 0 <= neighbor < len(paths) else None
           for neighbor in range(index - neighbors, index + neighbors + 1)
@@ -738,6 +739,38 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str) -> Non
   asyncio.run(run())
   assert len(rclip.browses) == (1 if query else 3)
   assert rclip.searches == ([(query, str(tmp_path), None, [], [])] if query else [])
+
+
+@pytest.mark.parametrize("result_count", [0, 1])
+def test_search_replacement_closes_obsolete_detail(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch, result_count: int
+) -> None:
+  results = [RClip.SearchResult(str(tmp_path / "new.jpg"), 1)][:result_count]
+  rclip = FakeRclip([RClip.SearchResult(str(tmp_path / "old.jpg"), 1)])
+  release = Event()
+
+  def slow_search(*args, **kwargs) -> list[RClip.SearchResult]:
+    assert release.wait(5)
+    return results
+
+  monkeypatch.setattr(rclip, "search", slow_search)
+  app = RclipApp(rclip, str(tmp_path))
+
+  async def run() -> None:
+    async with app.run_test(size=(80, 24)) as pilot:
+      try:
+        await app.workers.wait_for_complete()
+        await pilot.press("c", "a", "t", "enter", "down", "enter")
+        assert isinstance(app.screen, DetailScreen)
+      finally:
+        release.set()
+      await app.workers.wait_for_complete()
+      await pilot.resize_terminal(160, 24)
+      await pilot.pause()
+      assert not isinstance(app.screen, DetailScreen)
+      assert [card.result.filepath for card in app.query(ImageCard)] == [result.filepath for result in results]
+
+  asyncio.run(run())
 
 
 @pytest.mark.parametrize("action", ["left", "right", "escape"])


### PR DESCRIPTION
## How does this PR impact the user?

- Adds a clickable thumbnail strip beneath the image preview, sized to the terminal width with the current result centered.

## Description

- [x] add a responsive filmstrip with centered previews and smaller neighboring frames
- [x] reuse loaded thumbnails and keep the layout stable while browsing
- [x] fix image cleanup and refresh thumbnails when returning to the gallery
- [x] preserve pagination in narrow terminals and close obsolete detail views when search results change

## Limitations

- Final Kitty verification and screenshots are pending.
- Full-suite testing was blocked by a model-download DNS failure.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
