### PR TITLE
feat(tui): toggle between grid and detail gallery views

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Open the interactive UI and enter a query in its search input:
 rclip --interactive
 ```
 
-The UI requires Kitty graphics with Unicode-placeholder support. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches are ranked once and loaded in batches of up to 100 results as you scroll; pass `--top N` to use a smaller search batch. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and Detail view loads a higher-resolution display image. Grid and Detail are alternative views of the same results: switching preserves the query and selected image. Search is available in both views, with the selected image’s score and path shown below the results.
+The UI requires Kitty graphics with Unicode-placeholder support. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches are ranked once and loaded in batches of up to 100 results as you scroll; pass `--top N` to use a smaller search batch. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and Detail view loads a higher-resolution display image.
 
 | Key | Action |
 | --- | --- |
@@ -135,7 +135,6 @@ The UI requires Kitty graphics with Unicode-placeholder support. It uses the ter
 | `v` | Toggle between Grid and Detail while browsing. |
 | `Enter` | Submit the search query while typing. |
 | Left/Right or `h`/`l` | Show the previous or next image in Detail. |
-| Double-click | Switch views (selecting the clicked image in Grid). |
 | `Esc` | Move focus between search and browsing. |
 | `y` | Copy the selected image to the system clipboard using Kitty's `kitten clipboard`. |
 | `Y` | Copy the selected image path. |

--- a/README.md
+++ b/README.md
@@ -126,16 +126,17 @@ Open the interactive UI and enter a query in its search input:
 rclip --interactive
 ```
 
-The UI requires Kitty graphics with Unicode-placeholder support. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches are ranked once and loaded in batches of up to 100 results as you scroll; pass `--top N` to use a smaller search batch. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and opening a result loads a higher-resolution display image.
+The UI requires Kitty graphics with Unicode-placeholder support. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches are ranked once and loaded in batches of up to 100 results as you scroll; pass `--top N` to use a smaller search batch. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and Detail view loads a higher-resolution display image. Grid and Detail are alternative views of the same results: switching preserves the query and selected image. Search is available in both views, with the selected image’s score and path shown below the results.
 
 | Key | Action |
 | --- | --- |
 | `/` | Focus the search input. |
 | Arrow keys or `h`, `j`, `k`, `l` | Move between results. |
-| `Enter` | Open the selected image. |
-| Left/Right or `h`/`l` | Show the previous or next opened image. |
-| Double-click | Open an image, or return to the grid from an opened image. |
-| `Esc` | Return to the grid from an opened image. |
+| `v` | Toggle between Grid and Detail while browsing. |
+| `Enter` | Submit the search query while typing. |
+| Left/Right or `h`/`l` | Show the previous or next image in Detail. |
+| Double-click | Switch views (selecting the clicked image in Grid). |
+| `Esc` | Move focus between search and browsing. |
 | `y` | Copy the selected image to the system clipboard using Kitty's `kitten clipboard`. |
 | `Y` | Copy the selected image path. |
 | `d` | Download the selected original image from an SSH host. |

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -17,7 +17,7 @@ from rclip.tui.media import ImageWidget
 from rclip.tui.transfer import _is_remote_session
 from rclip.tui.transfer import copy_image_to_clipboard
 from rclip.tui.transfer import download_image
-from rclip.tui.views import DetailScreen
+from rclip.tui.views import DetailView
 from rclip.tui.views import ImageCard
 from rclip.tui.views import ResultsGrid
 from rclip.tui.views import TuiResult
@@ -49,8 +49,8 @@ class RclipApp(App[None]):
     Binding("k", "move_up", "Up", show=False),
     Binding("up", "move_up_or_focus", "Up", show=False),
     Binding("l,right", "move_right", "Right", show=False),
-    Binding("enter", "view", "View", show=False),
-    Binding("escape", "go_back", "Back", show=False),
+    Binding("v", "toggle_view", "Toggle view", show=False),
+    Binding("escape", "toggle_focus", "Search/Browse", show=False),
     Binding("y", "copy_image", "Copy image", show=False),
     Binding("Y", "copy_path", "Copy path", show=False),
     Binding("d", "download", "Download", show=False),
@@ -79,14 +79,16 @@ class RclipApp(App[None]):
     self._remaining_search_results: list[TuiResult] = []
     self._loading_more = False
     self._pending_detail_advance = False
+    self._detail = DetailView(self._move_detail)
 
   def compose(self) -> ComposeResult:
     directory = _display_directory(self.working_directory)
     yield Input(placeholder=f"Search images in {directory}…", id="search")
     yield ResultsGrid(self._load_more)
+    yield self._detail
     yield Static("", id="gallery-path", markup=False)
     yield Static(
-      "/ Search   hjkl/Arrows Move   Enter View   y Copy   Y Copy path   d Download   q/Ctrl+C Quit",
+      "/ Search   hjkl/Arrows Move   v Detail view   y Copy   Y Copy path   d Download   q/Ctrl+C Quit",
       classes="hotkeys",
       markup=False,
     )
@@ -124,9 +126,9 @@ class RclipApp(App[None]):
 
   def _load_more(self) -> None:
     if self._loading_more or (
-      isinstance(self.screen, DetailScreen)
+      self._detail.display
       and not self._pending_detail_advance
-      and self._selected_index + len(self.screen.thumbnails) // 2 < len(self._cards())
+      and self._selected_index + len(self._detail.thumbnails) // 2 < len(self._cards())
     ):
       return
     query = self.query_one("#search", Input).value.strip()
@@ -202,8 +204,6 @@ class RclipApp(App[None]):
       return
     grid = self.query_one(ResultsGrid)
     if not append:
-      if isinstance(self.screen, DetailScreen):
-        self.action_go_back()
       self.query_one("#gallery-path", Static).update("")
       await grid.remove_children()
       if not self._is_current_search(generation, query):
@@ -220,13 +220,13 @@ class RclipApp(App[None]):
     self._loading_more = False
     if append and self._pending_detail_advance:
       self._pending_detail_advance = False
-      if cards and isinstance(self.screen, DetailScreen):
+      if cards and self._detail.display:
         self._move_detail(1)
-    if append:
-      self._update_detail()
     if not append:
       grid.scroll_home(animate=False)
       self._selected_index = 0
+    if self._detail.display:
+      self._update_selection()
     self.call_after_refresh(grid.update_visible)
     search_input.border_title = None if append or results else "No results"
 
@@ -253,16 +253,12 @@ class RclipApp(App[None]):
       "move_up",
       "move_up_or_focus",
       "quit_navigation",
-      "view",
+      "toggle_view",
     }:
       return False
-    if isinstance(self.screen, DetailScreen) and action in {
-      "focus_search",
+    if self._detail.display and action in {
       "move_down",
-      "move_down_or_focus",
       "move_up",
-      "move_up_or_focus",
-      "view",
     }:
       return False
     if action == "focus_search":
@@ -273,21 +269,17 @@ class RclipApp(App[None]):
     cards = self._cards()
     if card in cards:
       self._selected_index = cards.index(card)
-      self.query_one("#gallery-path", Static).update(card.result.filepath)
+      self._update_selection()
       self.call_after_refresh(self.query_one(ResultsGrid).update_visible)
 
   def _cards(self) -> Sequence[ImageCard]:
     return self.query_one(ResultsGrid).cards
 
   def _selected_card(self) -> ImageCard | None:
-    if isinstance(self.focused, ImageCard):
-      return self.focused
     cards = self._cards()
     return cards[self._selected_index] if self._selected_index < len(cards) else None
 
   def _selected_filepath(self) -> str | None:
-    if isinstance(self.screen, DetailScreen):
-      return self.screen.filepath
     card = self._selected_card()
     return card.result.filepath if card else None
 
@@ -324,30 +316,36 @@ class RclipApp(App[None]):
     if index == self._selected_index:
       return
     self._selected_index = index
-    self._update_detail()
+    self._update_selection()
 
-  def _update_detail(self) -> None:
-    if not isinstance(self.screen, DetailScreen) or not self.screen.thumbnails:
+  def _update_selection(self) -> None:
+    card = self._selected_card()
+    label = ""
+    if card is not None:
+      result = card.result
+      label = result.filepath if result.score is None else f"{result.score:.3f}  {result.filepath}"
+    self.query_one("#gallery-path", Static).update(label)
+    if not self._detail.display:
+      return
+    self._detail.show_image(card.result.filepath if card else None)
+    if not self._detail.thumbnails:
       return
     cards = self._cards()
-    filepath = cards[self._selected_index].result.filepath
-    if self.screen.filepath != filepath:
-      self.screen.show_image(filepath)
-    neighbors = len(self.screen.thumbnails) // 2
-    self.screen.show_thumbnails([
+    neighbors = len(self._detail.thumbnails) // 2
+    self._detail.show_thumbnails([
       cards[index].result.filepath if 0 <= index < len(cards) else None
       for index in range(self._selected_index - neighbors, self._selected_index + neighbors + 1)
     ])
     self._load_more()
 
   def action_move_left(self) -> None:
-    if isinstance(self.screen, DetailScreen):
+    if self._detail.display:
       self._move_detail(-1)
     else:
       self._move(-1)
 
   def action_move_right(self) -> None:
-    if isinstance(self.screen, DetailScreen):
+    if self._detail.display:
       self._move_detail(1)
     else:
       self._move(1)
@@ -359,42 +357,51 @@ class RclipApp(App[None]):
     self._move(self._columns())
 
   def action_move_up_or_focus(self) -> None:
-    if isinstance(self.focused, ImageCard) and self._selected_index < self._columns():
+    if self._detail.display or (isinstance(self.focused, ImageCard) and self._selected_index < self._columns()):
       self.action_focus_search()
     else:
       self.action_move_up()
 
   def action_move_down_or_focus(self) -> None:
     if isinstance(self.focused, Input):
-      if card := self._selected_card():
-        card.focus()
-    else:
+      self.action_toggle_focus()
+    elif not self._detail.display:
       self.action_move_down()
 
   def action_focus_search(self) -> None:
     self.query_one("#search", Input).focus()
 
-  def action_view(self) -> None:
-    if card := self._selected_card():
-      self.push_screen(DetailScreen(card.result.filepath, self._move_detail))
-
-  def action_go_back(self) -> None:
+  def action_toggle_view(self) -> None:
     self._pending_detail_advance = False
-    if isinstance(self.screen, DetailScreen):
-      selected_index = self._selected_index
-      self.pop_screen()
-      # The terminal may have evicted gallery images while the detail view was active.
-      for image in self.query_one(ResultsGrid).query(ImageWidget):
-        image.refresh_image()
-      cards = self._cards()
-      if selected_index < len(cards):
-        self.call_after_refresh(cards[selected_index].focus)
-      return
-    if isinstance(self.focused, Input):
-      if card := self._selected_card():
-        card.focus()
+    grid = self.query_one(ResultsGrid)
+    grid.display = self._detail.display
+    self._detail.display = not grid.display
+    # The terminal may have evicted images while the other view was active.
+    for image in self.query(ImageWidget):
+      image.refresh_image()
+    self.query_one(".hotkeys", Static).update(
+      "/ Search   "
+      + ("h/l/Arrows Browse   v Grid view" if self._detail.display else "hjkl/Arrows Move   v Detail view")
+      + "   y Copy   Y Copy path   d Download   q/Ctrl+C Quit"
+    )
+    self._update_selection()
+    if self._detail.display:
+      self._detail.focus()
+    elif card := self._selected_card():
+      self.call_after_refresh(card.focus)
     else:
+      grid.focus()
+
+  def action_toggle_focus(self) -> None:
+    self._pending_detail_advance = False
+    if not isinstance(self.focused, Input):
       self.action_focus_search()
+    elif self._detail.display:
+      self._detail.focus()
+    elif card := self._selected_card():
+      card.focus()
+    else:
+      self.query_one(ResultsGrid).focus()
 
   def action_copy_path(self) -> None:
     if filepath := self._selected_filepath():

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -387,21 +387,16 @@ class RclipApp(App[None]):
     self._update_selection()
     if self._detail.display:
       self._detail.focus()
-    elif card := self._selected_card():
-      self.call_after_refresh(card.focus)
     else:
-      grid.focus()
+      self.call_after_refresh((self._selected_card() or grid).focus)
 
   def action_toggle_focus(self) -> None:
     self._pending_detail_advance = False
     if not isinstance(self.focused, Input):
       self.action_focus_search()
-    elif self._detail.display:
-      self._detail.focus()
-    elif card := self._selected_card():
-      card.focus()
     else:
-      self.query_one(ResultsGrid).focus()
+      target = self._detail if self._detail.display else self._selected_card() or self.query_one(ResultsGrid)
+      target.focus()
 
   def action_copy_path(self) -> None:
     if filepath := self._selected_filepath():

--- a/rclip/tui/app.tcss
+++ b/rclip/tui/app.tcss
@@ -65,6 +65,12 @@ ImageCard.preview-failed {
   text-align: center;
 }
 
+#detail {
+  width: 100%;
+  height: 1fr;
+  overflow: hidden hidden;
+}
+
 #detail-frame {
   height: 1fr;
   padding: 1;
@@ -77,7 +83,7 @@ ImageCard.preview-failed {
   max-height: 100%;
 }
 
-#detail-status, #detail-path, #gallery-path {
+#detail-status, #gallery-path {
   height: 1;
   padding: 0 1;
   color: $text-muted;

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -77,14 +77,6 @@ class ImageCard(Static, can_focus=True):
     if isinstance(self.app, RclipApp):
       self.app.select_card(self)
 
-  def on_click(self, event: events.Click) -> None:
-    from rclip.tui.app import RclipApp
-
-    if event.button == 1 and event.chain == 2 and isinstance(self.app, RclipApp):
-      self.focus()
-      self.app.select_card(self)
-      self.app.action_toggle_view()
-
 
 class ResultsGrid(ItemGrid, can_focus=True):
   def __init__(self, load_more: Callable[[], None]) -> None:
@@ -225,13 +217,6 @@ class DetailView(Vertical, can_focus=True):
     status.display = True
     if filepath is not None:
       self._load_detail()
-
-  def on_click(self, event: events.Click) -> None:
-    from rclip.tui.app import RclipApp
-
-    if event.button == 1 and event.chain == 2 and isinstance(self.app, RclipApp):
-      event.stop()
-      self.app.action_toggle_view()
 
   @work(thread=True, group="detail", exclusive=True, exit_on_error=False)
   def _load_detail(self) -> None:

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -7,8 +7,7 @@ from typing import Callable, Sequence, cast
 
 from textual import events, work
 from textual.app import ComposeResult
-from textual.containers import CenterMiddle, Horizontal, ItemGrid
-from textual.screen import Screen
+from textual.containers import CenterMiddle, Horizontal, ItemGrid, Vertical
 from textual.worker import get_current_worker
 from textual.widgets import Label, Static
 
@@ -84,10 +83,10 @@ class ImageCard(Static, can_focus=True):
     if event.button == 1 and event.chain == 2 and isinstance(self.app, RclipApp):
       self.focus()
       self.app.select_card(self)
-      self.app.action_view()
+      self.app.action_toggle_view()
 
 
-class ResultsGrid(ItemGrid):
+class ResultsGrid(ItemGrid, can_focus=True):
   def __init__(self, load_more: Callable[[], None]) -> None:
     super().__init__(
       id="results",
@@ -103,6 +102,8 @@ class ResultsGrid(ItemGrid):
     return cast(Sequence[ImageCard], self.children)
 
   def update_visible(self) -> None:
+    if not self.display:
+      return
     viewport = self.scrollable_content_region
     cards = self.cards
     index = bisect_right(cards, self.scroll_y, key=lambda card: card.virtual_region.bottom)
@@ -169,10 +170,11 @@ class DetailThumbnail(Static):
       self.browse(self.result_offset)
 
 
-class DetailScreen(Screen[None]):
-  def __init__(self, filepath: str, browse: Callable[[int], None]) -> None:
-    super().__init__()
-    self.filepath = filepath
+class DetailView(Vertical, can_focus=True):
+  def __init__(self, browse: Callable[[int], None]) -> None:
+    super().__init__(id="detail")
+    self.display = False
+    self.filepath: str | None = None
     self._image = ImageWidget(classes="detail-image")
     self._image.display = False
     self._browse = browse
@@ -181,17 +183,8 @@ class DetailScreen(Screen[None]):
   def compose(self) -> ComposeResult:
     with CenterMiddle(id="detail-frame"):
       yield self._image
-      yield Static("Loading higher-resolution image…", id="detail-status", markup=False)
+      yield Static("No results", id="detail-status", markup=False)
     yield Horizontal(id="detail-filmstrip")
-    yield Static(self.filepath, id="detail-path", markup=False)
-    yield Static(
-      "h/l/Arrows Browse   Esc/Double-click Back   y Copy   Y Copy path   d Download   q/Ctrl+C Quit",
-      classes="hotkeys",
-      markup=False,
-    )
-
-  def on_mount(self) -> None:
-    self._load_detail()
 
   async def on_resize(self, event: events.Resize) -> None:
     from rclip.tui.app import RclipApp
@@ -204,7 +197,7 @@ class DetailScreen(Screen[None]):
     self.thumbnails = [DetailThumbnail(offset, self._browse) for offset in range(-neighbors, neighbors + 1)]
     await filmstrip.mount(*self.thumbnails)
     if isinstance(self.app, RclipApp):
-      self.app._update_detail()
+      self.app._update_selection()
 
   def show_thumbnails(self, filepaths: list[str | None]) -> None:
     retained = {
@@ -221,26 +214,30 @@ class DetailScreen(Screen[None]):
       thumbnail.show_image(filepath)
       filmstrip.move_child(thumbnail, before=index)
 
-  def show_image(self, filepath: str) -> None:
+  def show_image(self, filepath: str | None) -> None:
+    if filepath == self.filepath:
+      return
     self.filepath = filepath
     self._image.display = False
     self._image.image = None
     status = self.query_one("#detail-status", Static)
-    status.update("Loading higher-resolution image…")
+    status.update("No results" if filepath is None else "Loading higher-resolution image…")
     status.display = True
-    self.query_one("#detail-path", Static).update(filepath)
-    self._load_detail()
+    if filepath is not None:
+      self._load_detail()
 
   def on_click(self, event: events.Click) -> None:
     from rclip.tui.app import RclipApp
 
     if event.button == 1 and event.chain == 2 and isinstance(self.app, RclipApp):
       event.stop()
-      self.app.action_go_back()
+      self.app.action_toggle_view()
 
   @work(thread=True, group="detail", exclusive=True, exit_on_error=False)
   def _load_detail(self) -> None:
     filepath = self.filepath
+    if filepath is None:
+      return
     with _IMAGE_DECODES:
       if get_current_worker().is_cancelled:
         return

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -496,12 +496,17 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
 
       await pilot.click("#detail-frame", times=2)
       await pilot.pause()
+      assert app.query_one(DetailView).display
+      await pilot.press("v")
       assert not app.query_one(DetailView).display
       assert app.focused is cards[1]
       assert str(gallery_path.content) == f"0.800  {paths[1]}"
 
       await pilot.click(cards[0], times=2)
       await pilot.pause()
+      assert not app.query_one(DetailView).display
+      assert app.focused is cards[0]
+      await pilot.press("v")
       assert app.query_one(DetailView).display
       await pilot.press("v")
       await pilot.pause()

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -479,38 +479,39 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
       await pilot.press("right")
       assert app.focused is cards[1]
       assert str(gallery_path.content) == f"0.800  {paths[1]}"
+      detail = app.query_one(DetailView)
       await pilot.press("enter")
-      assert not app.query_one(DetailView).display
+      assert not detail.display
       await pilot.press("v")
       await app.workers.wait_for_complete()
       await pilot.pause()
-      assert app.query_one(DetailView).display
-      assert app.query_one(DetailView).filepath == str(paths[1])
+      assert detail.display
+      assert detail.filepath == str(paths[1])
 
       await pilot.press("left")
       await app.workers.wait_for_complete()
-      assert app.query_one(DetailView).filepath == str(paths[0])
+      assert detail.filepath == str(paths[0])
       await pilot.press("right")
       await app.workers.wait_for_complete()
-      assert app.query_one(DetailView).filepath == str(paths[1])
+      assert detail.filepath == str(paths[1])
 
       await pilot.click("#detail-frame", times=2)
       await pilot.pause()
-      assert app.query_one(DetailView).display
+      assert detail.display
       await pilot.press("v")
-      assert not app.query_one(DetailView).display
+      assert not detail.display
       assert app.focused is cards[1]
       assert str(gallery_path.content) == f"0.800  {paths[1]}"
 
       await pilot.click(cards[0], times=2)
       await pilot.pause()
-      assert not app.query_one(DetailView).display
+      assert not detail.display
       assert app.focused is cards[0]
       await pilot.press("v")
-      assert app.query_one(DetailView).display
+      assert detail.display
       await pilot.press("v")
       await pilot.pause()
-      assert not app.query_one(DetailView).display
+      assert not detail.display
 
       await pilot.press("/")
       assert isinstance(app.focused, Input)
@@ -785,8 +786,9 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
         await app.workers.wait_for_complete()
       await pilot.pause()
       assert len(app.query(ImageCard)) == 25
+      detail = app.query_one(DetailView)
       await pilot.press("down", "v")
-      assert app.query_one(DetailView).display
+      assert detail.display
       for index, path in enumerate(paths[1:], 1):
         await pilot.press("right")
         if width == 80 and index == 22:
@@ -799,15 +801,12 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
           for neighbor in range(index - neighbors, index + neighbors + 1)
         ]
         async with asyncio.timeout(0.25):
-          while (
-            app.query_one(DetailView).filepath != path
-            or [thumbnail.filepath for thumbnail in app.query_one(DetailView).thumbnails] != expected
-          ):
+          while detail.filepath != path or [thumbnail.filepath for thumbnail in detail.thumbnails] != expected:
             await pilot.pause(0.01)
       await pilot.press("right")
-      assert app.query_one(DetailView).filepath == paths[-1]
+      assert detail.filepath == paths[-1]
       await pilot.press("left")
-      assert app.query_one(DetailView).filepath == paths[-2]
+      assert detail.filepath == paths[-2]
       await pilot.press("v")
       await pilot.pause()
       async with asyncio.timeout(0.25):

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -29,7 +29,7 @@ from rclip.tui.transfer import TransferError
 from rclip.tui.transfer import _download_protocol
 from rclip.tui.transfer import copy_image_to_clipboard
 from rclip.tui.transfer import download_image
-from rclip.tui.views import DetailScreen
+from rclip.tui.views import DetailView
 from rclip.tui.views import ImageCard
 from rclip.tui.views import ResultsGrid
 from rclip.utils.helpers import init_arg_parser
@@ -465,7 +465,7 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
 
       await pilot.press("down")
       assert app.focused is cards[0]
-      assert str(gallery_path.content) == str(paths[0])
+      assert str(gallery_path.content) == f"0.900  {paths[0]}"
 
       await pilot.press("Y")
       assert copied == [str(paths[0])]
@@ -478,32 +478,34 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
 
       await pilot.press("right")
       assert app.focused is cards[1]
-      assert str(gallery_path.content) == str(paths[1])
+      assert str(gallery_path.content) == f"0.800  {paths[1]}"
       await pilot.press("enter")
+      assert not app.query_one(DetailView).display
+      await pilot.press("v")
       await app.workers.wait_for_complete()
       await pilot.pause()
-      assert isinstance(app.screen, DetailScreen)
-      assert app.screen.filepath == str(paths[1])
+      assert app.query_one(DetailView).display
+      assert app.query_one(DetailView).filepath == str(paths[1])
 
       await pilot.press("left")
       await app.workers.wait_for_complete()
-      assert app.screen.filepath == str(paths[0])
+      assert app.query_one(DetailView).filepath == str(paths[0])
       await pilot.press("right")
       await app.workers.wait_for_complete()
-      assert app.screen.filepath == str(paths[1])
+      assert app.query_one(DetailView).filepath == str(paths[1])
 
       await pilot.click("#detail-frame", times=2)
       await pilot.pause()
-      assert not isinstance(app.screen, DetailScreen)
+      assert not app.query_one(DetailView).display
       assert app.focused is cards[1]
-      assert str(gallery_path.content) == str(paths[1])
+      assert str(gallery_path.content) == f"0.800  {paths[1]}"
 
       await pilot.click(cards[0], times=2)
       await pilot.pause()
-      assert isinstance(app.screen, DetailScreen)
-      await pilot.press("escape")
+      assert app.query_one(DetailView).display
+      await pilot.press("v")
       await pilot.pause()
-      assert not isinstance(app.screen, DetailScreen)
+      assert not app.query_one(DetailView).display
 
       await pilot.press("/")
       assert isinstance(app.focused, Input)
@@ -517,6 +519,67 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
       assert str(gallery_path.content) == ""
       await pilot.press("ctrl+c")
       assert exits == [True]
+
+  asyncio.run(run())
+
+
+def test_search_in_detail_preserves_view_and_updates_selection(tmp_path: Path) -> None:
+  paths = [str(make_image(tmp_path / f"image-{index}.jpg")) for index in range(3)]
+  rclip = FakeRclip([RClip.SearchResult(path, 0.9 - index / 10) for index, path in enumerate(paths)])
+  app = RclipApp(rclip, str(tmp_path))
+
+  async def run() -> None:
+    async with app.run_test(size=(100, 40)) as pilot:
+      await app.workers.wait_for_complete()
+      await pilot.press("down", "right", "v")
+      detail = app.query_one(DetailView)
+      search = app.query_one(Input)
+      status = app.query_one("#gallery-path", Static)
+      assert detail.display and detail.filepath == paths[1]
+      assert str(status.content) == paths[1]
+      assert search.visible and search.region.bottom <= detail.region.y
+
+      await pilot.press("/")
+      assert app.focused is search
+      await pilot.press("v")
+      assert search.value == "v"
+      assert detail.display
+      rclip.results = [RClip.SearchResult(paths[2], 0.75), RClip.SearchResult(paths[0], 0.25)]
+      await pilot.press("enter")
+      await app.workers.wait_for_complete()
+      assert detail.display and detail.filepath == paths[2]
+      assert str(status.content) == f"0.750  {paths[2]}"
+      assert app.focused is search
+      await pilot.press("escape", "right")
+      assert app.focused is detail
+      assert detail.filepath == paths[0]
+      assert str(status.content) == f"0.250  {paths[0]}"
+      await pilot.press("v")
+      assert not detail.display
+      assert isinstance(app.focused, ImageCard)
+      assert app.focused.result.filepath == paths[0]
+      assert search.value == "v"
+      assert [card.result.filepath for card in app.query(ImageCard)] == [paths[2], paths[0]]
+      await pilot.press("v", "up")
+      assert detail.display and app.focused is search
+
+      rclip.results = []
+      await pilot.press("x", "enter")
+      await app.workers.wait_for_complete()
+      assert detail.display and detail.filepath is None
+      assert detail._image.image is None
+      assert all(thumbnail.filepath is None for thumbnail in detail.thumbnails)
+      assert str(status.content) == ""
+      assert search.border_title == "No results"
+      await pilot.press("down", "v", "v")
+      assert detail.display and app.focused is detail
+
+      rclip.results = [RClip.SearchResult(paths[1], 0.8)]
+      await pilot.press("/", "backspace", "enter")
+      await app.workers.wait_for_complete()
+      assert search.value == ""
+      assert detail.display and detail.filepath == paths[1]
+      assert str(status.content) == paths[1]
 
   asyncio.run(run())
 
@@ -537,7 +600,7 @@ def test_gallery_resends_thumbnails_after_detail_browsing(tmp_path: Path, monkey
       await pilot.pause()
       before = [card._image.render() for card in cards]
       assert all(isinstance(renderable, TGPRenderable) for renderable in before)
-      await pilot.press("down", "enter", "right", "right", "left", "escape")
+      await pilot.press("down", "v", "right", "right", "left", "v")
       await app.workers.wait_for_complete()
       await pilot.pause()
       for card, previous in zip(cards, before):
@@ -572,10 +635,10 @@ def test_detail_loading_and_error_keep_layout_stable(tmp_path: Path, monkeypatch
     async with app.run_test(size=(100, 40)) as pilot:
       try:
         await app.workers.wait_for_complete()
-        await pilot.press("down", "enter")
+        await pilot.press("down", "v")
         assert await asyncio.to_thread(started.wait, 1)
-        screen = app.screen
-        assert isinstance(screen, DetailScreen)
+        screen = app.query_one(DetailView)
+        assert screen.display
         status = screen.query_one("#detail-status", Static)
         frame = screen.query_one("#detail-frame")
         filmstrip = screen.query_one("#detail-filmstrip")
@@ -615,10 +678,10 @@ def test_filmstrip_reuses_loaded_neighbors_while_new_thumbnail_loads(
   async def run() -> None:
     async with app.run_test(size=(100, 40)) as pilot:
       await app.workers.wait_for_complete()
-      await pilot.press("down", "enter", "right", "right")
+      await pilot.press("down", "v", "right", "right")
       await app.workers.wait_for_complete()
-      screen = app.screen
-      assert isinstance(screen, DetailScreen)
+      screen = app.query_one(DetailView)
+      assert screen.display
       loaded = {thumbnail.filepath: (thumbnail, thumbnail._image.image) for thumbnail in screen.thumbnails}
       monkeypatch.setattr("rclip.tui.views.prepare_image", slow_prepare)
       try:
@@ -647,10 +710,10 @@ def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> Non
   async def run() -> None:
     async with app.run_test(size=(100, 40)) as pilot:
       await app.workers.wait_for_complete()
-      await pilot.press("down", "enter")
+      await pilot.press("down", "v")
       await app.workers.wait_for_complete()
-      screen = app.screen
-      assert isinstance(screen, DetailScreen)
+      screen = app.query_one(DetailView)
+      assert screen.display
       assert [thumbnail.filepath for thumbnail in screen.thumbnails] == [None, None, *paths[:3]]
       assert all(thumbnail._image.image is not None for thumbnail in screen.thumbnails[2:])
       assert all(not thumbnail.visible for thumbnail in screen.thumbnails[:2])
@@ -693,7 +756,7 @@ def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> Non
       await app.workers.wait_for_complete()
       assert screen.filepath == paths[3]
       assert screen.thumbnails[len(screen.thumbnails) // 2].filepath == paths[3]
-      await pilot.press("escape")
+      await pilot.press("v")
       assert isinstance(app.focused, ImageCard)
       assert app.focused.result.filepath == paths[3]
 
@@ -717,8 +780,8 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
         await app.workers.wait_for_complete()
       await pilot.pause()
       assert len(app.query(ImageCard)) == 25
-      await pilot.press("down", "enter")
-      assert isinstance(app.screen, DetailScreen)
+      await pilot.press("down", "v")
+      assert app.query_one(DetailView).display
       for index, path in enumerate(paths[1:], 1):
         await pilot.press("right")
         if width == 80 and index == 22:
@@ -731,13 +794,16 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
           for neighbor in range(index - neighbors, index + neighbors + 1)
         ]
         async with asyncio.timeout(0.25):
-          while app.screen.filepath != path or [thumbnail.filepath for thumbnail in app.screen.thumbnails] != expected:
+          while (
+            app.query_one(DetailView).filepath != path
+            or [thumbnail.filepath for thumbnail in app.query_one(DetailView).thumbnails] != expected
+          ):
             await pilot.pause(0.01)
       await pilot.press("right")
-      assert app.screen.filepath == paths[-1]
+      assert app.query_one(DetailView).filepath == paths[-1]
       await pilot.press("left")
-      assert app.screen.filepath == paths[-2]
-      await pilot.press("escape")
+      assert app.query_one(DetailView).filepath == paths[-2]
+      await pilot.press("v")
       await pilot.pause()
       async with asyncio.timeout(0.25):
         while app.focused is not app.query_one(ResultsGrid).cards[-2]:
@@ -750,7 +816,7 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
 
 
 @pytest.mark.parametrize("result_count", [0, 1])
-def test_search_replacement_closes_obsolete_detail(
+def test_search_replacement_preserves_detail(
   tmp_path: Path, monkeypatch: pytest.MonkeyPatch, result_count: int
 ) -> None:
   results = [RClip.SearchResult(str(tmp_path / "new.jpg"), 1)][:result_count]
@@ -768,20 +834,23 @@ def test_search_replacement_closes_obsolete_detail(
     async with app.run_test(size=(80, 24)) as pilot:
       try:
         await app.workers.wait_for_complete()
-        await pilot.press("c", "a", "t", "enter", "down", "enter")
-        assert isinstance(app.screen, DetailScreen)
+        await pilot.press("c", "a", "t", "enter", "down", "v")
+        assert app.query_one(DetailView).display
       finally:
         release.set()
       await app.workers.wait_for_complete()
       await pilot.resize_terminal(160, 24)
       await pilot.pause()
-      assert not isinstance(app.screen, DetailScreen)
+      detail = app.query_one(DetailView)
+      assert detail.display
+      assert detail.filepath == (results[0].filepath if results else None)
+      assert str(app.query_one("#gallery-path", Static).content) == (f"1.000  {results[0].filepath}" if results else "")
       assert [card.result.filepath for card in app.query(ImageCard)] == [result.filepath for result in results]
 
   asyncio.run(run())
 
 
-@pytest.mark.parametrize("action", ["left", "right", "escape"])
+@pytest.mark.parametrize("action", ["left", "right", "v"])
 def test_detail_navigation_handles_pending_advance(
   tmp_path: Path, monkeypatch: pytest.MonkeyPatch, action: str
 ) -> None:
@@ -806,7 +875,7 @@ def test_detail_navigation_handles_pending_advance(
     async with app.run_test(size=(80, 24)) as pilot:
       try:
         await app.workers.wait_for_complete()
-        await pilot.press("down", "enter")
+        await pilot.press("down", "v")
         await pilot.press(*(["right"] * 25))
         assert await asyncio.to_thread(started.wait, 1)
         await pilot.press("right", action)
@@ -815,11 +884,11 @@ def test_detail_navigation_handles_pending_advance(
       await app.workers.wait_for_complete()
       await pilot.pause()
       assert len(app.query(ImageCard)) == 26
-      if action != "escape":
-        assert isinstance(app.screen, DetailScreen)
-        assert app.screen.filepath == paths[23 if action == "left" else 25]
+      if action != "v":
+        assert app.query_one(DetailView).display
+        assert app.query_one(DetailView).filepath == paths[23 if action == "left" else 25]
       else:
-        assert not isinstance(app.screen, DetailScreen)
+        assert not app.query_one(DetailView).display
         assert isinstance(app.focused, ImageCard)
         assert app.focused.result.filepath == paths[24]
 
@@ -1048,13 +1117,13 @@ def test_search_loads_more_on_scroll(tmp_path: Path) -> None:
 
       await pilot.press("down")
       gallery_path = app.query_one("#gallery-path", Static)
-      assert str(gallery_path.content) == str(paths[0])
+      assert str(gallery_path.content) == f"1.000  {paths[0]}"
       app.query_one(ResultsGrid).scroll_end(animate=False)
       async with asyncio.timeout(0.25):
         while len(app.query(ImageCard)) != 26:
           await asyncio.sleep(0.01)
       assert [card.result.filepath for card in app.query(ImageCard)] == [str(path) for path in paths]
-      assert str(gallery_path.content) == str(paths[0])
+      assert str(gallery_path.content) == f"1.000  {paths[0]}"
 
   asyncio.run(run())
 
@@ -1100,7 +1169,7 @@ def test_empty_browse_retries_loading_more_after_failure(
 
       grid = app.query_one(ResultsGrid)
       if detail:
-        await pilot.press("down", "enter", *(["right"] * 23))
+        await pilot.press("down", "v", *(["right"] * 23))
       else:
         grid.scroll_end(animate=False)
       async with asyncio.timeout(0.25):
@@ -1110,8 +1179,8 @@ def test_empty_browse_retries_loading_more_after_failure(
       assert notifications == [("page failed", "Unable to load more images")]
 
       if detail:
-        assert isinstance(app.screen, DetailScreen)
-        assert app.screen.filepath == str(paths[23])
+        assert app.query_one(DetailView).display
+        assert app.query_one(DetailView).filepath == str(paths[23])
         await pilot.press("right")
       else:
         grid.scroll_home(animate=False)
@@ -1122,8 +1191,8 @@ def test_empty_browse_retries_loading_more_after_failure(
         while [card.result.filepath for card in app.query(ImageCard)] != expected:
           await asyncio.sleep(0.01)
       if detail:
-        assert isinstance(app.screen, DetailScreen)
-        assert app.screen.filepath == str(paths[24])
+        assert app.query_one(DetailView).display
+        assert app.query_one(DetailView).filepath == str(paths[24])
 
   asyncio.run(run())
 


### PR DESCRIPTION
## How does this PR impact the user?

- Use `v` to switch between Grid and Detail while keeping the query, result order, and selected image. Search stays available in both views, with the selected image's score and path below the results. `Esc` moves focus between search and browsing; `Enter` submits search.

<img width="860" height="622" alt="image" src="https://github.com/user-attachments/assets/b810b7b1-ec3c-4b98-b4ec-ea4e94f00fc4" />

## Description

- [x] make Grid and Detail share one screen, search input, selection, and status line
- [x] preserve the chosen view through searches and empty results, and update shortcuts and documentation
- [x] add behavioral coverage for shared search, scores, focus, and view switching, and adapt existing navigation and pagination tests

## Validation

- 200 unit tests passed; the two packaging tests passed after rerunning with a writable `UV_CACHE_DIR`.
- Ruff, ty, and `git diff --check` passed.

## Checklist

- [x] my PR is focused and contains one holistic change
- [x] I have added screenshots or screen recordings to show the changes
