### PR TITLE
fix: improve TUI border visibility and focus contrast

### DIFF
--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -81,6 +81,14 @@ class RclipApp(App[None]):
     self._pending_detail_advance = False
     self._detail = DetailView(self._move_detail)
 
+  def get_css_variables(self) -> dict[str, str]:
+    variables = super().get_css_variables()
+    if self.current_theme.name == "ansi-dark":
+      # Keep borders visible while respecting the terminal's ANSI palette.
+      variables["border-blurred"] = "ansi_white"
+      variables["border"] = "ansi_bright_green"
+    return variables
+
   def compose(self) -> ComposeResult:
     directory = _display_directory(self.working_directory)
     yield Input(placeholder=f"Search images in {directory}…", id="search")

--- a/rclip/tui/app.tcss
+++ b/rclip/tui/app.tcss
@@ -7,12 +7,12 @@ Screen {
 #search {
   height: 3;
   margin: 1 1 0 1;
-  border: round $border-blurred;
+  border: solid $border-blurred;
   background: $surface;
 }
 
 #search:focus {
-  border: round $accent;
+  border: heavy $border;
 }
 
 #results {
@@ -26,13 +26,13 @@ Screen {
 ImageCard {
   height: 16;
   layout: vertical;
-  border: round $border-blurred;
+  border: solid $border-blurred;
   background: $surface;
   padding: 0 1;
 }
 
 ImageCard:focus {
-  border: heavy $accent;
+  border: heavy $border;
   background: $block-hover-background;
 }
 
@@ -54,7 +54,7 @@ ImageCard:focus {
 }
 
 ImageCard.preview-failed {
-  border: round $error;
+  border: solid $error;
 }
 
 .hotkeys {
@@ -105,13 +105,13 @@ ImageCard.preview-failed {
   width: 90%;
   height: 7;
   padding: 0 1;
-  border: round $border-blurred;
+  border: solid $border-blurred;
 }
 
 .detail-thumbnail.selected .detail-thumbnail-frame {
   width: 100%;
   height: 100%;
-  border: heavy $accent;
+  border: heavy $border;
 }
 
 .detail-thumbnail-frame .thumbnail {


### PR DESCRIPTION
## How does this PR impact the user?

- Make inactive borders visible in dark terminal palettes and distinguish focused widgets by border thickness across the search input, grid cards, and filmstrip thumbnails.

<img width="856" height="629" alt="image" src="https://github.com/user-attachments/assets/0ee2b252-5aa6-442c-bf2e-4e28697e64ba" />

## Description

- [x] use ANSI white for inactive borders and bright green for active borders in the default `ansi-dark` theme
- [x] make borders consistently rectangular, with thin inactive borders and heavy active borders

## Limitations

- Border shades depend on the terminal's configured ANSI palette.

## Checklist

- [x] my PR is focused and contains one holistic change
- [x] I have added screenshots or screen recordings to show the changes
