### PR TITLE
test: increase detail navigation test deadline to 500 ms

### DIFF
--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -800,7 +800,7 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
           paths[neighbor] if 0 <= neighbor < len(paths) else None
           for neighbor in range(index - neighbors, index + neighbors + 1)
         ]
-        async with asyncio.timeout(0.25):
+        async with asyncio.timeout(0.5):
           while detail.filepath != path or [thumbnail.filepath for thumbnail in detail.thumbnails] != expected:
             await pilot.pause(0.01)
       await pilot.press("right")


### PR DESCRIPTION
## How does this PR impact the user?

- Reduce timing sensitivity in the detail navigation test on CI.

## Description

- [x] increase the detail navigation readiness deadline from 250 ms to 500 ms

## Limitations

- Windows validation depends on CI.

## Validation

- All four detail navigation pagination cases pass locally on macOS/Python 3.13.
- Ruff and `git diff --check` pass.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
