### PR TITLE
feat(tui): clarify gallery scope and ordering

### DIFF
--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, ClassVar, Sequence
 from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
+from textual.containers import Horizontal
 from textual.timer import Timer
 from textual.worker import get_current_worker
 from textual.widgets import Input, Static
@@ -92,8 +93,9 @@ class RclipApp(App[None]):
   def compose(self) -> ComposeResult:
     directory = _display_directory(self.working_directory)
     yield Input(placeholder=f"Search images in {directory}…", id="search")
-    yield Static(f"{directory} · Including subfolders", id="search-scope", markup=False)
-    yield Static("All images · Recently modified first", id="results-order", markup=False)
+    with Horizontal(id="gallery-labels"):
+      yield Static(f"{directory} · Including subfolders", id="search-scope", markup=False)
+      yield Static("All images · Recently modified first", id="results-order", markup=False)
     yield ResultsGrid(self._load_more)
     yield self._detail
     yield Static("", id="gallery-path", markup=False)

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -92,6 +92,8 @@ class RclipApp(App[None]):
   def compose(self) -> ComposeResult:
     directory = _display_directory(self.working_directory)
     yield Input(placeholder=f"Search images in {directory}…", id="search")
+    yield Static(f"{directory} · Including subfolders", id="search-scope", markup=False)
+    yield Static("All images · Recently modified first", id="results-order", markup=False)
     yield ResultsGrid(self._load_more)
     yield self._detail
     yield Static("", id="gallery-path", markup=False)
@@ -226,6 +228,9 @@ class RclipApp(App[None]):
       return
     self._next_cursor = next_cursor
     self._loading_more = False
+    self.query_one("#results-order", Static).update(
+      "Search results · Most similar first" if query else "All images · Recently modified first"
+    )
     if append and self._pending_detail_advance:
       self._pending_detail_advance = False
       if cards and self._detail.display:

--- a/rclip/tui/app.tcss
+++ b/rclip/tui/app.tcss
@@ -15,6 +15,13 @@ Screen {
   border: heavy $border;
 }
 
+#search-scope, #results-order {
+  height: 1;
+  padding: 0 1;
+  color: $text-muted;
+  text-overflow: ellipsis;
+}
+
 #results {
   height: 1fr;
   grid-gutter: 1;

--- a/rclip/tui/app.tcss
+++ b/rclip/tui/app.tcss
@@ -34,6 +34,7 @@ Screen {
 
 #results {
   height: 1fr;
+  margin-top: 1;
   grid-gutter: 1;
   grid-rows: 16;
   overflow-x: hidden;

--- a/rclip/tui/app.tcss
+++ b/rclip/tui/app.tcss
@@ -15,11 +15,21 @@ Screen {
   border: heavy $border;
 }
 
-#search-scope, #results-order {
+#gallery-labels {
   height: 1;
   padding: 0 1;
+}
+
+#search-scope, #results-order {
+  width: 1fr;
+  height: 1;
   color: $text-muted;
   text-overflow: ellipsis;
+}
+
+#results-order {
+  margin-left: 2;
+  text-align: right;
 }
 
 #results {

--- a/rclip/tui/app.tcss
+++ b/rclip/tui/app.tcss
@@ -34,7 +34,6 @@ Screen {
 
 #results {
   height: 1fr;
-  margin-top: 1;
   grid-gutter: 1;
   grid-rows: 16;
   overflow-x: hidden;

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -1040,7 +1040,7 @@ def test_tui_only_loads_visible_previews(tmp_path: Path, monkeypatch: pytest.Mon
   monkeypatch.setattr("rclip.tui.views.prepare_image", prepare)
 
   async def run() -> None:
-    async with app.run_test(size=(80, 24)) as pilot:
+    async with app.run_test(size=(80, 26)) as pilot:
       assert await asyncio.to_thread(four_started.wait, 1)
       await asyncio.sleep(0.05)
       assert max_active == 4

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -1040,7 +1040,7 @@ def test_tui_only_loads_visible_previews(tmp_path: Path, monkeypatch: pytest.Mon
   monkeypatch.setattr("rclip.tui.views.prepare_image", prepare)
 
   async def run() -> None:
-    async with app.run_test(size=(80, 26)) as pilot:
+    async with app.run_test(size=(80, 25)) as pilot:
       assert await asyncio.to_thread(four_started.wait, 1)
       await asyncio.sleep(0.05)
       assert max_active == 4

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -1040,7 +1040,7 @@ def test_tui_only_loads_visible_previews(tmp_path: Path, monkeypatch: pytest.Mon
   monkeypatch.setattr("rclip.tui.views.prepare_image", prepare)
 
   async def run() -> None:
-    async with app.run_test(size=(80, 25)) as pilot:
+    async with app.run_test(size=(80, 26)) as pilot:
       assert await asyncio.to_thread(four_started.wait, 1)
       await asyncio.sleep(0.05)
       assert max_active == 4


### PR DESCRIPTION
## How does this PR impact the user?

- Explain the image scope and ordering in a single row below search: directory scope on the left, “All images · Recently modified first” or “Search results · Most similar first” on the right.
- Keep a gap between the labels and truncate them on narrow terminals.
- Validation: TUI tests, Ruff, ty, and headless layout checks at 24, 40, 80, and 120 columns.

<img width="854" height="621" alt="image" src="https://github.com/user-attachments/assets/56eee371-483c-4403-ba1c-8f6839aebf30" />

<img width="860" height="621" alt="image" src="https://github.com/user-attachments/assets/9e4e5257-1382-43c9-9553-059528633513" />

## Description

- [x] add a single row of aligned directory scope and gallery ordering labels
- [x] update the ordering label when results arrive
- [x] adjust the preview concurrency test height to preserve its gallery viewport

## Limitations

- Labels use one additional terminal row and truncate when space is limited.
- Screenshots are not attached.

## Checklist

- [x] my PR is focused and contains one holistic change
- [x] I have added screenshots or screen recordings to show the changes
