### PR TITLE
fix(tui): improve hotkeys and detail navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The UI requires Kitty graphics with Unicode-placeholder support. It uses the ter
 | Download image | Ctrl+S | s |
 | Quit | Ctrl+C | |
 
-Use Ctrl on macOS too. In search, Enter runs the query immediately and Down or Esc focuses the results. In the grid, arrows or hjkl navigate and Enter opens detail; in detail, Left/Right or h/l browse images. Esc returns from detail to the grid. Use Ctrl+F or / to return from browsing to search. Double-click a grid image to open detail and the main detail image to return; click a filmstrip thumbnail to select it.
+In search, Enter runs the query immediately and Down or Esc focuses the results. In the grid, arrows or hjkl navigate and Enter opens detail; in detail, Left/Right or h/l browse images. Esc returns from detail to the grid. Use Ctrl+F or / to return from browsing to search. Double-click a grid image to open detail and the main detail image to return; click a filmstrip thumbnail to select it.
 
 Copy and download act on the focused grid result or the displayed detail image. They are unavailable while search is focused in the grid. In detail, their modifier shortcuts work while typing, and Ctrl+O preserves search focus and cursor position in either view. Download transfers remote images to your computer through a supported terminal.
 

--- a/README.md
+++ b/README.md
@@ -128,23 +128,22 @@ rclip --interactive
 
 The UI requires Kitty graphics with Unicode-placeholder support. It uses the terminal's default colors and ANSI palette. With an empty query it browses recently modified images, loading more as you scroll. Searches are ranked once and loaded in batches of up to 100 results as you scroll; pass `--top N` to use a smaller search batch. Enter text queries in the UI; image queries remain available in the non-interactive CLI. Cached previews load as they become visible, and Detail view loads a higher-resolution display image.
 
-| Key | Action |
-| --- | --- |
-| `/` | Focus the search input. |
-| Arrow keys or `h`, `j`, `k`, `l` | Move between results. |
-| `v` | Toggle between Grid and Detail while browsing. |
-| `Enter` | Submit the search query while typing. |
-| Left/Right or `h`/`l` | Show the previous or next image in Detail. |
-| `Esc` | Move focus between search and browsing. |
-| `y` | Copy the selected image to the system clipboard using Kitty's `kitten clipboard`. |
-| `Y` | Copy the selected image path. |
-| `d` | Download the selected original image from an SSH host. |
-| `q` | Quit while navigating results. |
-| `Ctrl+C` or `Ctrl+Q` | Quit from anywhere, including the search input. |
+| Action | Shortcut | Browse alias |
+| --- | --- | --- |
+| Focus search | Ctrl+F | / |
+| Toggle grid/detail | Ctrl+O | o |
+| Copy image | Ctrl+Y | y |
+| Copy image path | Ctrl+P | Y |
+| Download image | Ctrl+S | s |
+| Quit | Ctrl+C | |
+
+Use Ctrl on macOS too. In search, Enter runs the query immediately and Down or Esc focuses the results. In the grid, arrows or hjkl navigate and Enter opens detail; in detail, Left/Right or h/l browse images. Esc returns from detail to the grid. Use Ctrl+F or / to return from browsing to search. Double-click a grid image to open detail and the main detail image to return; click a filmstrip thumbnail to select it.
+
+Copy and download act on the focused grid result or the displayed detail image. They are unavailable while search is focused in the grid. In detail, their modifier shortcuts work while typing, and Ctrl+O preserves search focus and cursor position in either view. Download transfers remote images to your computer through a supported terminal.
 
 Image copying requires Kitty 0.27 or newer and a discoverable `kitten` executable; the rest of the UI does not invoke Kitty executables.
 
-Over SSH, `d` downloads the original file to `~/Downloads` on the terminal host. Kitty 0.30+ requires a remote `kitten` executable (`kitten ssh` provides it) and asks for confirmation; iTerm2 3.5+ is also supported. If detection fails, set `RCLIP_DOWNLOAD_PROTOCOL` to `kitty` or `iterm2`. Locally, `d` only shows the file path.
+Over SSH, `Ctrl+S` or `s` downloads the original file to `~/Downloads` on the terminal host. Kitty 0.30+ requires a remote `kitten` executable (`kitten ssh` provides it) and asks for confirmation; iTerm2 3.5+ is also supported. If detection fails, set `RCLIP_DOWNLOAD_PROTOCOL` to `kitty` or `iterm2`. Locally, the same shortcuts only shows the file path.
 
 ### Similar image search (image-to-image search)
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The UI requires Kitty graphics with Unicode-placeholder support. It uses the ter
 | Focus search | Ctrl+F | / |
 | Toggle grid/detail | Ctrl+O | o |
 | Copy image | Ctrl+Y | y |
-| Copy image path | Ctrl+P | Y |
+| Copy image path | Ctrl+P | p |
 | Download image | Ctrl+S | s |
 | Quit | Ctrl+C | |
 

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -448,15 +448,15 @@ class RclipApp(App[None], inherit_bindings=False):
 
   def _update_hotkeys(self) -> None:
     search_focused = isinstance(self.focused, Input)
-    keys = ["Down/Esc Browse"] if search_focused else ["^F / Search"]
+    keys = ["Down Browse"] if search_focused else ["/ Search"]
     if search_focused:
       keys.append("^O Grid view" if self._detail.display else "^O Detail view")
     elif self._detail.display:
-      keys.append("h/l/Arrows Browse   Esc/^O Grid view")
+      keys.append("h/l/Arrows Browse   Esc Grid view")
     else:
-      keys.append("hjkl/Arrows Move   Enter/^O Detail view")
+      keys.append("hjkl/Arrows Move   o Detail view")
     if self.check_action("copy_image", ()):
-      keys.append("^Y Copy   ^P Copy path   ^S Download")
+      keys.append("^Y Copy   ^P Copy path   ^S Download" if search_focused else "y Copy   Y Copy path   s Download")
     keys.append("^C Quit")
     self.query_one(".hotkeys", Static).update("   ".join(keys))
 

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -55,7 +55,7 @@ class RclipApp(App[None], inherit_bindings=False):
     Binding("enter", "open_detail", "Open", show=False),
     Binding("escape", "escape", "Search/Browse", show=False),
     Binding("ctrl+y,y", "copy_image", "Copy image", show=False),
-    Binding("ctrl+p,Y", "copy_path", "Copy path", show=False),
+    Binding("ctrl+p,p", "copy_path", "Copy path", show=False),
     Binding("ctrl+s,s", "download", "Download", show=False),
     Binding("ctrl+c", "quit", "Quit", show=False, priority=True),
   ]
@@ -456,7 +456,7 @@ class RclipApp(App[None], inherit_bindings=False):
     else:
       keys.append("hjkl/Arrows Move   o Detail view")
     if self.check_action("copy_image", ()):
-      keys.append("^Y Copy   ^P Copy path   ^S Download" if search_focused else "y Copy   Y Copy path   s Download")
+      keys.append("^Y Copy   ^P Copy path   ^S Download" if search_focused else "y Copy   p Copy path   s Download")
     keys.append("^C Quit")
     self.query_one(".hotkeys", Static).update("   ".join(keys))
 

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -448,16 +448,16 @@ class RclipApp(App[None], inherit_bindings=False):
 
   def _update_hotkeys(self) -> None:
     search_focused = isinstance(self.focused, Input)
-    keys = ["Down/Esc Browse"] if search_focused else ["Ctrl+F / Search"]
+    keys = ["Down/Esc Browse"] if search_focused else ["^F / Search"]
     if search_focused:
-      keys.append("Ctrl+O Grid view" if self._detail.display else "Ctrl+O Detail view")
+      keys.append("^O Grid view" if self._detail.display else "^O Detail view")
     elif self._detail.display:
-      keys.append("h/l/Arrows Browse   Esc/Ctrl+O Grid view")
+      keys.append("h/l/Arrows Browse   Esc/^O Grid view")
     else:
-      keys.append("hjkl/Arrows Move   Enter/Ctrl+O Detail view")
+      keys.append("hjkl/Arrows Move   Enter/^O Detail view")
     if self.check_action("copy_image", ()):
-      keys.append("Ctrl+Y Copy   Ctrl+P Copy path   Ctrl+S Download")
-    keys.append("Ctrl+C Quit")
+      keys.append("^Y Copy   ^P Copy path   ^S Download")
+    keys.append("^C Quit")
     self.query_one(".hotkeys", Static).update("   ".join(keys))
 
   @work(thread=True, group="clipboard", exclusive=True, exit_on_error=False)

--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING, ClassVar, Sequence
 
-from textual import work
+from textual import events, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
@@ -36,13 +36,14 @@ def _display_directory(directory: str) -> str:
   return str(Path("~") / relative)
 
 
-class RclipApp(App[None]):
+class RclipApp(App[None], inherit_bindings=False):
   TITLE = "rclip"
+  ENABLE_COMMAND_PALETTE = False
   CSS_PATH = "app.tcss"
   BROWSE_BATCH_SIZE = 25
 
   BINDINGS: ClassVar[list[Binding]] = [
-    Binding("/", "focus_search", "Search", show=False),
+    Binding("ctrl+f,/", "focus_search", "Search", show=False),
     Binding("h,left", "move_left", "Left", show=False),
     # Making j or k switch focus would prevent typing that key in the search input.
     Binding("j", "move_down", "Down", show=False),
@@ -50,14 +51,13 @@ class RclipApp(App[None]):
     Binding("k", "move_up", "Up", show=False),
     Binding("up", "move_up_or_focus", "Up", show=False),
     Binding("l,right", "move_right", "Right", show=False),
-    Binding("v", "toggle_view", "Toggle view", show=False),
-    Binding("escape", "toggle_focus", "Search/Browse", show=False),
-    Binding("y", "copy_image", "Copy image", show=False),
-    Binding("Y", "copy_path", "Copy path", show=False),
-    Binding("d", "download", "Download", show=False),
-    Binding("q", "quit_navigation", "Quit", show=False),
+    Binding("ctrl+o,o", "toggle_view", "Toggle view", show=False),
+    Binding("enter", "open_detail", "Open", show=False),
+    Binding("escape", "escape", "Search/Browse", show=False),
+    Binding("ctrl+y,y", "copy_image", "Copy image", show=False),
+    Binding("ctrl+p,Y", "copy_path", "Copy path", show=False),
+    Binding("ctrl+s,s", "download", "Download", show=False),
     Binding("ctrl+c", "quit", "Quit", show=False, priority=True),
-    Binding("ctrl+q", "quit", "Quit", show=False, priority=True),
   ]
 
   def __init__(
@@ -99,11 +99,7 @@ class RclipApp(App[None]):
     yield ResultsGrid(self._load_more)
     yield self._detail
     yield Static("", id="gallery-path", markup=False)
-    yield Static(
-      "/ Search   hjkl/Arrows Move   v Detail view   y Copy   Y Copy path   d Download   q/Ctrl+C Quit",
-      classes="hotkeys",
-      markup=False,
-    )
+    yield Static("", classes="hotkeys", markup=False)
 
   def on_mount(self) -> None:
     self.query_one("#search", Input).focus()
@@ -259,18 +255,18 @@ class RclipApp(App[None]):
 
   def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
     if isinstance(self.focused, Input) and action in {
-      "copy_image",
-      "copy_path",
-      "download",
       "move_down",
       "move_left",
       "move_right",
       "move_up",
       "move_up_or_focus",
-      "quit_navigation",
-      "toggle_view",
+      "open_detail",
     }:
       return False
+    if action in {"copy_image", "copy_path", "download"}:
+      return self._selected_card() is not None and (self._detail.display or isinstance(self.focused, ImageCard))
+    if action == "open_detail":
+      return not self._detail.display and isinstance(self.focused, ImageCard)
     if self._detail.display and action in {
       "move_down",
       "move_up",
@@ -340,6 +336,7 @@ class RclipApp(App[None]):
       result = card.result
       label = result.filepath if result.score is None else f"{result.score:.3f}  {result.filepath}"
     self.query_one("#gallery-path", Static).update(label)
+    self._update_hotkeys()
     if not self._detail.display:
       return
     self._detail.show_image(card.result.filepath if card else None)
@@ -387,6 +384,7 @@ class RclipApp(App[None]):
     self.query_one("#search", Input).focus()
 
   def action_toggle_view(self) -> None:
+    search_focused = isinstance(self.focused, Input)
     self._pending_detail_advance = False
     grid = self.query_one(ResultsGrid)
     grid.display = self._detail.display
@@ -394,13 +392,10 @@ class RclipApp(App[None]):
     # The terminal may have evicted images while the other view was active.
     for image in self.query(ImageWidget):
       image.refresh_image()
-    self.query_one(".hotkeys", Static).update(
-      "/ Search   "
-      + ("h/l/Arrows Browse   v Grid view" if self._detail.display else "hjkl/Arrows Move   v Detail view")
-      + "   y Copy   Y Copy path   d Download   q/Ctrl+C Quit"
-    )
     self._update_selection()
-    if self._detail.display:
+    if search_focused:
+      self.action_focus_search()
+    elif self._detail.display:
       self._detail.focus()
     else:
       self.call_after_refresh((self._selected_card() or grid).focus)
@@ -436,8 +431,34 @@ class RclipApp(App[None]):
     else:
       self.notify("Saved to ~/Downloads", title=Path(filepath).name)
 
-  def action_quit_navigation(self) -> None:
-    self.exit()
+  def action_open_detail(self) -> None:
+    self.action_toggle_view()
+
+  def action_escape(self) -> None:
+    if isinstance(self.focused, Input):
+      self.action_toggle_focus()
+    elif self._detail.display:
+      self.action_toggle_view()
+
+  def on_descendant_focus(self, event: events.DescendantFocus) -> None:
+    self._update_hotkeys()
+
+  def on_descendant_blur(self, event: events.DescendantBlur) -> None:
+    self.call_after_refresh(self._update_hotkeys)
+
+  def _update_hotkeys(self) -> None:
+    search_focused = isinstance(self.focused, Input)
+    keys = ["Down/Esc Browse"] if search_focused else ["Ctrl+F / Search"]
+    if search_focused:
+      keys.append("Ctrl+O Grid view" if self._detail.display else "Ctrl+O Detail view")
+    elif self._detail.display:
+      keys.append("h/l/Arrows Browse   Esc/Ctrl+O Grid view")
+    else:
+      keys.append("hjkl/Arrows Move   Enter/Ctrl+O Detail view")
+    if self.check_action("copy_image", ()):
+      keys.append("Ctrl+Y Copy   Ctrl+P Copy path   Ctrl+S Download")
+    keys.append("Ctrl+C Quit")
+    self.query_one(".hotkeys", Static).update("   ".join(keys))
 
   @work(thread=True, group="clipboard", exclusive=True, exit_on_error=False)
   def _copy_image(self, filepath: str) -> None:

--- a/rclip/tui/app.tcss
+++ b/rclip/tui/app.tcss
@@ -75,7 +75,7 @@ ImageCard.preview-failed {
 }
 
 .hotkeys {
-  height: 1;
+  height: auto;
   padding: 0 1;
   background: $surface;
   color: $text-muted;

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -83,7 +83,7 @@ class ImageCard(Static, can_focus=True):
   def on_focus(self) -> None:
     from rclip.tui.app import RclipApp
 
-    if isinstance(self.app, RclipApp):
+    if isinstance(self.app, RclipApp) and self.app.focused is self:
       self.app.select_card(self)
 
 

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -71,6 +71,15 @@ class ImageCard(Static, can_focus=True):
     self._loaded = True
     self.add_class("preview-failed")
 
+  def on_click(self, event: events.Click) -> None:
+    from rclip.tui.app import RclipApp
+
+    if event.button == 1 and event.chain == 2 and isinstance(self.app, RclipApp):
+      event.stop()
+      self.focus()
+      self.app.select_card(self)
+      self.app.action_open_detail()
+
   def on_focus(self) -> None:
     from rclip.tui.app import RclipApp
 
@@ -177,6 +186,21 @@ class DetailView(Vertical, can_focus=True):
       yield self._image
       yield Static("No results", id="detail-status", markup=False)
     yield Horizontal(id="detail-filmstrip")
+
+  def on_click(self, event: events.Click) -> None:
+    from rclip.tui.app import RclipApp
+
+    frame = self.query_one("#detail-frame")
+    if (
+      event.button == 1
+      and event.chain == 2
+      and event.widget is not None
+      and (event.widget is frame or frame in event.widget.ancestors)
+      and isinstance(self.app, RclipApp)
+    ):
+      event.stop()
+      self.focus()
+      self.app.action_toggle_view()
 
   async def on_resize(self, event: events.Resize) -> None:
     from rclip.tui.app import RclipApp

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -468,7 +468,7 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
       assert app.focused is cards[0]
       assert str(gallery_path.content) == f"0.900  {paths[0]}"
 
-      await pilot.press("Y")
+      await pilot.press("p")
       assert copied == [str(paths[0])]
       await pilot.press("s")
       assert downloaded == [str(paths[0])]
@@ -599,8 +599,8 @@ def test_modifier_hotkeys_respect_visible_target_and_preserve_search(
       assert search.cursor_position == 1
 
       # Letter aliases remain text while editing, including in detail view.
-      await pilot.press("o", "y", "Y", "s", "q")
-      assert search.value == "coyYsqat"
+      await pilot.press("o", "y", "p", "s", "q")
+      assert search.value == "coypsqat"
       assert detail.display and exits == []
       assert len(copied_images) == len(copied_paths) == len(downloaded) == 2
 

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -604,6 +604,13 @@ def test_modifier_hotkeys_respect_visible_target_and_preserve_search(
       assert detail.display and exits == []
       assert len(copied_images) == len(copied_paths) == len(downloaded) == 2
 
+      # Finish the edited query before navigating its replacement result cards.
+      await pilot.press("enter")
+      await app.workers.wait_for_complete()
+      async with asyncio.timeout(1):
+        while search.border_title == "Searching…":
+          await pilot.pause()
+
       await pilot.press("ctrl+o")
       assert not detail.display and app.focused is search
       await pilot.press("ctrl+y", "ctrl+p", "ctrl+s")

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -15,6 +15,7 @@ from rich.console import Console
 from textual_image.renderable import TGPImage as TGPRenderable
 from textual_image._terminal import CellSize
 import pytest
+from textual import events
 from textual.geometry import Size
 from textual.widgets import Input, Static
 
@@ -520,6 +521,33 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
       assert str(gallery_path.content) == ""
       await pilot.press("ctrl+c")
       assert exits == [True]
+
+  asyncio.run(run())
+
+
+@pytest.mark.parametrize(("forward", "back"), [("right", "left"), ("down", "up")])
+def test_grid_navigation_keeps_selection_after_queued_arrows(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch, forward: str, back: str
+) -> None:
+  results = [RClip.SearchResult(str(tmp_path / f"image-{index}.jpg"), 1) for index in range(15)]
+  app = RclipApp(FakeRclip(results), str(tmp_path))
+  monkeypatch.setattr(ImageCard, "load_preview", lambda self: None)
+
+  async def run() -> None:
+    async with app.run_test(size=(100, 40)) as pilot:
+      await app.workers.wait_for_complete()
+      await pilot.press("down")
+      cards = app.query_one(ResultsGrid).cards
+      # Terminal input can arrive in a batch before deferred focus events run.
+      step = 1 if forward == "right" else app._columns()
+      for key in [forward, forward, back]:
+        app.post_message(events.Key(key, None))
+      await pilot.pause()
+      assert app.focused is cards[step]
+      assert app._selected_index == step
+      await pilot.press(back)
+      assert app.focused is cards[0]
+      assert app._selected_index == 0
 
   asyncio.run(run())
 

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -469,10 +469,10 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
 
       await pilot.press("Y")
       assert copied == [str(paths[0])]
-      await pilot.press("d")
+      await pilot.press("s")
       assert downloaded == [str(paths[0])]
       monkeypatch.delenv("SSH_CONNECTION")
-      await pilot.press("d")
+      await pilot.press("s")
       assert downloaded == [str(paths[0])]
       assert notifications[-1] == (str(paths[0]), "Image is already local")
 
@@ -481,8 +481,7 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
       assert str(gallery_path.content) == f"0.800  {paths[1]}"
       detail = app.query_one(DetailView)
       await pilot.press("enter")
-      assert not detail.display
-      await pilot.press("v")
+      assert detail.display
       await app.workers.wait_for_complete()
       await pilot.pause()
       assert detail.display
@@ -497,19 +496,15 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
 
       await pilot.click("#detail-frame", times=2)
       await pilot.pause()
-      assert detail.display
-      await pilot.press("v")
       assert not detail.display
       assert app.focused is cards[1]
       assert str(gallery_path.content) == f"0.800  {paths[1]}"
 
       await pilot.click(cards[0], times=2)
       await pilot.pause()
-      assert not detail.display
-      assert app.focused is cards[0]
-      await pilot.press("v")
       assert detail.display
-      await pilot.press("v")
+      assert app.focused is detail
+      await pilot.press("o")
       await pilot.pause()
       assert not detail.display
 
@@ -529,6 +524,78 @@ def test_tui_search_navigation_detail_and_copy_path(tmp_path: Path, monkeypatch:
   asyncio.run(run())
 
 
+def test_modifier_hotkeys_respect_visible_target_and_preserve_search(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  paths = [str(make_image(tmp_path / f"image-{index}.jpg")) for index in range(2)]
+  app = RclipApp(FakeRclip([RClip.SearchResult(path, 0.9) for path in paths]), str(tmp_path))
+  copied_images: list[str] = []
+  copied_paths: list[str] = []
+  downloaded: list[str] = []
+  exits: list[bool] = []
+  monkeypatch.setattr(app, "_copy_image", copied_images.append)
+  monkeypatch.setattr(app, "copy_to_clipboard", copied_paths.append)
+  monkeypatch.setattr(app, "suspend", nullcontext)
+  monkeypatch.setattr("rclip.tui.app.download_image", downloaded.append)
+  monkeypatch.setenv("SSH_CONNECTION", "client 1 server 2")
+  monkeypatch.setattr(app, "exit", lambda *args, **kwargs: exits.append(True))
+
+  async def run() -> None:
+    async with app.run_test(size=(100, 40)) as pilot:
+      await app.workers.wait_for_complete()
+      async with asyncio.timeout(1):
+        while len(app.query(ImageCard)) != 2:
+          await pilot.pause()
+      search = app.query_one(Input)
+      detail = app.query_one(DetailView)
+      await pilot.press("ctrl+y", "ctrl+p", "ctrl+s")
+      assert copied_images == copied_paths == downloaded == []
+      assert app.focused is search
+
+      await pilot.press("c", "a", "t", "enter")
+      await app.workers.wait_for_complete()
+      async with asyncio.timeout(1):
+        while app.query_one(Input).border_title == "Searching…":
+          await pilot.pause()
+      await pilot.press("down", "right", "ctrl+y", "ctrl+p", "ctrl+s")
+      assert copied_images == copied_paths == downloaded == [paths[1]]
+      await pilot.press("ctrl+f")
+      search.cursor_position = 1
+      await pilot.press("ctrl+o")
+      assert detail.display and detail.filepath == paths[1]
+      assert app.focused is search
+      assert search.cursor_position == 1
+      await pilot.press("ctrl+y", "ctrl+p", "ctrl+s")
+      assert copied_images == copied_paths == downloaded == [paths[1], paths[1]]
+      assert app.focused is search and search.value == "cat"
+      assert search.cursor_position == 1
+
+      # Letter aliases remain text while editing, including in detail view.
+      await pilot.press("o", "y", "Y", "s", "q")
+      assert search.value == "coyYsqat"
+      assert detail.display and exits == []
+      assert len(copied_images) == len(copied_paths) == len(downloaded) == 2
+
+      await pilot.press("ctrl+o")
+      assert not detail.display and app.focused is search
+      await pilot.press("ctrl+y", "ctrl+p", "ctrl+s")
+      assert len(copied_images) == len(copied_paths) == len(downloaded) == 2
+      await pilot.press("escape", "enter")
+      assert detail.display and app.focused is detail
+      await pilot.press("escape")
+      assert not detail.display and isinstance(app.focused, ImageCard)
+      await pilot.press("q", "ctrl+q")
+      assert exits == []
+      await pilot.press("escape")
+      assert isinstance(app.focused, ImageCard)
+      await pilot.press("ctrl+f")
+      assert app.focused is search
+      await pilot.press("ctrl+c")
+      assert exits == [True]
+
+  asyncio.run(run())
+
+
 def test_search_in_detail_preserves_view_and_updates_selection(tmp_path: Path) -> None:
   paths = [str(make_image(tmp_path / f"image-{index}.jpg")) for index in range(3)]
   rclip = FakeRclip([RClip.SearchResult(path, 0.9 - index / 10) for index, path in enumerate(paths)])
@@ -537,7 +604,7 @@ def test_search_in_detail_preserves_view_and_updates_selection(tmp_path: Path) -
   async def run() -> None:
     async with app.run_test(size=(100, 40)) as pilot:
       await app.workers.wait_for_complete()
-      await pilot.press("down", "right", "v")
+      await pilot.press("down", "right", "o")
       detail = app.query_one(DetailView)
       search = app.query_one(Input)
       status = app.query_one("#gallery-path", Static)
@@ -547,8 +614,8 @@ def test_search_in_detail_preserves_view_and_updates_selection(tmp_path: Path) -
 
       await pilot.press("/")
       assert app.focused is search
-      await pilot.press("v")
-      assert search.value == "v"
+      await pilot.press("o")
+      assert search.value == "o"
       assert detail.display
       rclip.results = [RClip.SearchResult(paths[2], 0.75), RClip.SearchResult(paths[0], 0.25)]
       await pilot.press("enter")
@@ -560,13 +627,13 @@ def test_search_in_detail_preserves_view_and_updates_selection(tmp_path: Path) -
       assert app.focused is detail
       assert detail.filepath == paths[0]
       assert str(status.content) == f"0.250  {paths[0]}"
-      await pilot.press("v")
+      await pilot.press("o")
       assert not detail.display
       assert isinstance(app.focused, ImageCard)
       assert app.focused.result.filepath == paths[0]
-      assert search.value == "v"
+      assert search.value == "o"
       assert [card.result.filepath for card in app.query(ImageCard)] == [paths[2], paths[0]]
-      await pilot.press("v", "up")
+      await pilot.press("o", "up")
       assert detail.display and app.focused is search
 
       rclip.results = []
@@ -577,7 +644,7 @@ def test_search_in_detail_preserves_view_and_updates_selection(tmp_path: Path) -
       assert all(thumbnail.filepath is None for thumbnail in detail.thumbnails)
       assert str(status.content) == ""
       assert search.border_title == "No results"
-      await pilot.press("down", "v", "v")
+      await pilot.press("down", "o", "o")
       assert detail.display and app.focused is detail
 
       rclip.results = [RClip.SearchResult(paths[1], 0.8)]
@@ -606,7 +673,7 @@ def test_gallery_resends_thumbnails_after_detail_browsing(tmp_path: Path, monkey
       await pilot.pause()
       before = [card._image.render() for card in cards]
       assert all(isinstance(renderable, TGPRenderable) for renderable in before)
-      await pilot.press("down", "v", "right", "right", "left", "v")
+      await pilot.press("down", "o", "right", "right", "left", "o")
       await app.workers.wait_for_complete()
       await pilot.pause()
       for card, previous in zip(cards, before):
@@ -641,7 +708,7 @@ def test_detail_loading_and_error_keep_layout_stable(tmp_path: Path, monkeypatch
     async with app.run_test(size=(100, 40)) as pilot:
       try:
         await app.workers.wait_for_complete()
-        await pilot.press("down", "v")
+        await pilot.press("down", "o")
         assert await asyncio.to_thread(started.wait, 1)
         screen = app.query_one(DetailView)
         assert screen.display
@@ -684,7 +751,7 @@ def test_filmstrip_reuses_loaded_neighbors_while_new_thumbnail_loads(
   async def run() -> None:
     async with app.run_test(size=(100, 40)) as pilot:
       await app.workers.wait_for_complete()
-      await pilot.press("down", "v", "right", "right")
+      await pilot.press("down", "o", "right", "right")
       await app.workers.wait_for_complete()
       screen = app.query_one(DetailView)
       assert screen.display
@@ -716,7 +783,7 @@ def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> Non
   async def run() -> None:
     async with app.run_test(size=(100, 40)) as pilot:
       await app.workers.wait_for_complete()
-      await pilot.press("down", "v")
+      await pilot.press("down", "o")
       await app.workers.wait_for_complete()
       screen = app.query_one(DetailView)
       assert screen.display
@@ -724,9 +791,9 @@ def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> Non
       assert all(thumbnail._image.image is not None for thumbnail in screen.thumbnails[2:])
       assert all(not thumbnail.visible for thumbnail in screen.thumbnails[:2])
       assert all(thumbnail.visible for thumbnail in screen.thumbnails[2:])
-      await pilot.click(screen.thumbnails[4])
+      await pilot.click(screen.thumbnails[4], times=2)
       await app.workers.wait_for_complete()
-      assert screen.filepath == paths[2]
+      assert screen.display and screen.filepath == paths[2]
       assert [thumbnail.filepath for thumbnail in screen.thumbnails] == paths
       await pilot.pause()
       selected_size = screen.thumbnails[2]._image.content_size
@@ -762,7 +829,7 @@ def test_detail_filmstrip_centers_selection_and_navigates(tmp_path: Path) -> Non
       await app.workers.wait_for_complete()
       assert screen.filepath == paths[3]
       assert screen.thumbnails[len(screen.thumbnails) // 2].filepath == paths[3]
-      await pilot.press("v")
+      await pilot.press("o")
       assert isinstance(app.focused, ImageCard)
       assert app.focused.result.filepath == paths[3]
 
@@ -787,7 +854,7 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
       await pilot.pause()
       assert len(app.query(ImageCard)) == 25
       detail = app.query_one(DetailView)
-      await pilot.press("down", "v")
+      await pilot.press("down", "o")
       assert detail.display
       for index, path in enumerate(paths[1:], 1):
         await pilot.press("right")
@@ -807,7 +874,7 @@ def test_detail_navigation_loads_more_results(tmp_path: Path, query: str, width:
       assert detail.filepath == paths[-1]
       await pilot.press("left")
       assert detail.filepath == paths[-2]
-      await pilot.press("v")
+      await pilot.press("o")
       await pilot.pause()
       async with asyncio.timeout(0.25):
         while app.focused is not app.query_one(ResultsGrid).cards[-2]:
@@ -838,7 +905,7 @@ def test_search_replacement_preserves_detail(
     async with app.run_test(size=(80, 24)) as pilot:
       try:
         await app.workers.wait_for_complete()
-        await pilot.press("c", "a", "t", "enter", "down", "v")
+        await pilot.press("c", "a", "t", "enter", "down", "o")
         assert app.query_one(DetailView).display
       finally:
         release.set()
@@ -854,7 +921,7 @@ def test_search_replacement_preserves_detail(
   asyncio.run(run())
 
 
-@pytest.mark.parametrize("action", ["left", "right", "v"])
+@pytest.mark.parametrize("action", ["left", "right", "o"])
 def test_detail_navigation_handles_pending_advance(
   tmp_path: Path, monkeypatch: pytest.MonkeyPatch, action: str
 ) -> None:
@@ -879,7 +946,7 @@ def test_detail_navigation_handles_pending_advance(
     async with app.run_test(size=(80, 24)) as pilot:
       try:
         await app.workers.wait_for_complete()
-        await pilot.press("down", "v")
+        await pilot.press("down", "o")
         await pilot.press(*(["right"] * 25))
         assert await asyncio.to_thread(started.wait, 1)
         await pilot.press("right", action)
@@ -888,7 +955,7 @@ def test_detail_navigation_handles_pending_advance(
       await app.workers.wait_for_complete()
       await pilot.pause()
       assert len(app.query(ImageCard)) == 26
-      if action != "v":
+      if action != "o":
         assert app.query_one(DetailView).display
         assert app.query_one(DetailView).filepath == paths[23 if action == "left" else 25]
       else:
@@ -1173,7 +1240,7 @@ def test_empty_browse_retries_loading_more_after_failure(
 
       grid = app.query_one(ResultsGrid)
       if detail:
-        await pilot.press("down", "v", *(["right"] * 23))
+        await pilot.press("down", "o", *(["right"] * 23))
       else:
         grid.scroll_end(animate=False)
       async with asyncio.timeout(0.25):


### PR DESCRIPTION
## How does this PR impact the user?

- Use Ctrl shortcuts while typing in detail view without losing search focus; copy and download require a visible image target.
- Open detail with Enter, Ctrl+O, or a double-click, and return with Esc, Ctrl+O, or a double-click. Use Ctrl+F or / to focus search.
- Validation: 201 unit tests and 34 end-to-end tests pass; focused navigation tests cover the final Esc change. Ruff, type checks, and git diff checks pass.

## Description

- [x] add modifier shortcuts with browse aliases and keep Ctrl+C as the sole quit shortcut
- [x] implement focus-aware image actions and Enter/Esc/double-click view navigation
- [x] update the contextual shortcut footer, documentation, and behavioral tests

## Limitations

- No terminal screenshots or recordings attached.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
