### PR TITLE
feat(tui): preload adjacent detail images

### DIFF
--- a/rclip/tui/app.py
+++ b/rclip/tui/app.py
@@ -342,10 +342,14 @@ class RclipApp(App[None], inherit_bindings=False):
     self._update_hotkeys()
     if not self._detail.display:
       return
-    self._detail.show_image(card.result.filepath if card else None)
+    cards = self._cards()
+    self._detail.show_image(card.result.filepath if card else None, [
+      cards[index].result.filepath
+      for index in (self._selected_index - 1, self._selected_index + 1)
+      if 0 <= index < len(cards)
+    ])
     if not self._detail.thumbnails:
       return
-    cards = self._cards()
     neighbors = len(self._detail.thumbnails) // 2
     self._detail.show_thumbnails([
       cards[index].result.filepath if 0 <= index < len(cards) else None

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -8,7 +8,7 @@ from typing import Callable, Sequence, cast
 from textual import events, work
 from textual.app import ComposeResult
 from textual.containers import CenterMiddle, Horizontal, ItemGrid, Vertical
-from textual.worker import get_current_worker
+from textual.worker import Worker, get_current_worker
 from textual.widgets import Label, Static
 
 from rclip.tui.media import CenteredTGPImage
@@ -180,6 +180,8 @@ class DetailView(Vertical, can_focus=True):
     self._image.display = False
     self._browse = browse
     self.thumbnails: list[DetailThumbnail] = []
+    self._details: dict[str, BytesIO | str] = {}
+    self._detail_workers: dict[str, Worker[None]] = {}
 
   def compose(self) -> ComposeResult:
     with CenterMiddle(id="detail-frame"):
@@ -230,7 +232,15 @@ class DetailView(Vertical, can_focus=True):
       thumbnail.show_image(filepath)
       filmstrip.move_child(thumbnail, before=index)
 
-  def show_image(self, filepath: str | None) -> None:
+  def show_image(self, filepath: str | None, neighbors: Sequence[str] = ()) -> None:
+    wanted = {filepath, *neighbors} if filepath is not None else set()
+    self._details = {path: detail for path, detail in self._details.items() if path in wanted}
+    for path in list(self._detail_workers):
+      if path not in wanted:
+        self._detail_workers.pop(path).cancel()
+    for path in ([filepath, *neighbors] if filepath is not None else []):
+      if path not in self._details and path not in self._detail_workers:
+        self._detail_workers[path] = self._load_detail(path)
     if filepath == self.filepath:
       return
     self.filepath = filepath
@@ -239,23 +249,36 @@ class DetailView(Vertical, can_focus=True):
     status = self.query_one("#detail-status", Static)
     status.update("No results" if filepath is None else "Loading higher-resolution image…")
     status.display = True
-    if filepath is not None:
-      self._load_detail()
+    if filepath in self._details:
+      detail = self._details[filepath]
+      if isinstance(detail, BytesIO):
+        self._show_detail(filepath, detail)
+      else:
+        self._show_error(filepath, detail)
 
-  @work(thread=True, group="detail", exclusive=True, exit_on_error=False)
-  def _load_detail(self) -> None:
-    filepath = self.filepath
-    if filepath is None:
-      return
+  @work(thread=True, group="detail", exit_on_error=False)
+  def _load_detail(self, filepath: str) -> None:
+    worker = get_current_worker()
     with _IMAGE_DECODES:
-      if get_current_worker().is_cancelled:
+      if worker.is_cancelled:
         return
+      detail: BytesIO | str
       try:
         detail = prepare_image(filepath, DETAIL_SIZE)
       except Exception as error:
-        self.app.call_from_thread(self._show_error, filepath, str(error))
-      else:
-        self.app.call_from_thread(self._show_detail, filepath, detail)
+        detail = str(error)
+      if not worker.is_cancelled:
+        self.app.call_from_thread(self._detail_ready, filepath, worker, detail)
+
+  def _detail_ready(self, filepath: str, worker: Worker[None], detail: BytesIO | str) -> None:
+    if not self.is_attached or self._detail_workers.get(filepath) is not worker:
+      return
+    del self._detail_workers[filepath]
+    self._details[filepath] = detail
+    if isinstance(detail, BytesIO):
+      self._show_detail(filepath, detail)
+    else:
+      self._show_error(filepath, detail)
 
   def _show_detail(self, filepath: str, detail: BytesIO) -> None:
     if not self.is_attached or filepath != self.filepath:

--- a/rclip/tui/views.py
+++ b/rclip/tui/views.py
@@ -233,12 +233,12 @@ class DetailView(Vertical, can_focus=True):
       filmstrip.move_child(thumbnail, before=index)
 
   def show_image(self, filepath: str | None, neighbors: Sequence[str] = ()) -> None:
-    wanted = {filepath, *neighbors} if filepath is not None else set()
+    wanted = [filepath, *neighbors] if filepath is not None else []
     self._details = {path: detail for path, detail in self._details.items() if path in wanted}
     for path in list(self._detail_workers):
       if path not in wanted:
         self._detail_workers.pop(path).cancel()
-    for path in ([filepath, *neighbors] if filepath is not None else []):
+    for path in wanted:
       if path not in self._details and path not in self._detail_workers:
         self._detail_workers[path] = self._load_detail(path)
     if filepath == self.filepath:
@@ -250,11 +250,7 @@ class DetailView(Vertical, can_focus=True):
     status.update("No results" if filepath is None else "Loading higher-resolution image…")
     status.display = True
     if filepath in self._details:
-      detail = self._details[filepath]
-      if isinstance(detail, BytesIO):
-        self._show_detail(filepath, detail)
-      else:
-        self._show_error(filepath, detail)
+      self._show_detail(filepath, self._details[filepath])
 
   @work(thread=True, group="detail", exit_on_error=False)
   def _load_detail(self, filepath: str) -> None:
@@ -275,18 +271,15 @@ class DetailView(Vertical, can_focus=True):
       return
     del self._detail_workers[filepath]
     self._details[filepath] = detail
-    if isinstance(detail, BytesIO):
-      self._show_detail(filepath, detail)
-    else:
-      self._show_error(filepath, detail)
+    self._show_detail(filepath, detail)
 
-  def _show_detail(self, filepath: str, detail: BytesIO) -> None:
+  def _show_detail(self, filepath: str, detail: BytesIO | str) -> None:
     if not self.is_attached or filepath != self.filepath:
+      return
+    status = self.query_one("#detail-status", Static)
+    if isinstance(detail, str):
+      status.update(f"Unable to load image: {detail}")
       return
     self._image.image = detail
     self._image.display = True
-    self.query_one("#detail-status", Static).display = False
-
-  def _show_error(self, filepath: str, message: str) -> None:
-    if self.is_attached and filepath == self.filepath:
-      self.query_one("#detail-status", Static).update(f"Unable to load image: {message}")
+    status.display = False

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -694,6 +694,7 @@ def test_search_in_detail_preserves_view_and_updates_selection(tmp_path: Path) -
 
 def test_gallery_resends_thumbnails_after_detail_browsing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
   monkeypatch.setattr(sys, "__stdout__", StringIO())
+  console = Console(file=StringIO(), width=100, height=40)
   paths = [make_image(tmp_path / f"image-{index}.jpg") for index in range(6)]
   app = RclipApp(FakeRclip([RClip.SearchResult(str(path), 1) for path in paths]), str(tmp_path))
 
@@ -707,7 +708,10 @@ def test_gallery_resends_thumbnails_after_detail_browsing(tmp_path: Path, monkey
       await app.workers.wait_for_complete()
       await pilot.pause()
       before = [card._image.render() for card in cards]
-      assert all(isinstance(renderable, TGPRenderable) for renderable in before)
+      for renderable in before:
+        assert isinstance(renderable, TGPRenderable)
+        list(console.render(renderable))
+        assert renderable.terminal_image_id is not None
       await pilot.press("down", "o", "right", "right", "left", "o")
       await app.workers.wait_for_complete()
       await pilot.pause()
@@ -717,6 +721,8 @@ def test_gallery_resends_thumbnails_after_detail_browsing(tmp_path: Path, monkey
         current = card._image.render()
         assert isinstance(current, TGPRenderable)
         assert current is not previous
+        # Widget.render() only returns the renderable; Rich performs the image transfer.
+        list(console.render(current))
         assert current.terminal_image_id is not None
       await pilot.press("right", "left")
       assert all(card._image.image is not None for card in cards)

--- a/tests/unit/test_tui.py
+++ b/tests/unit/test_tui.py
@@ -724,6 +724,96 @@ def test_gallery_resends_thumbnails_after_detail_browsing(tmp_path: Path, monkey
   asyncio.run(run())
 
 
+@pytest.mark.parametrize("width", [30, 100])
+def test_detail_preloads_only_adjacent_images_and_navigates_immediately(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch, width: int
+) -> None:
+  paths = [str(make_image(tmp_path / f"image-{index}.jpg")) for index in range(5)]
+  app = RclipApp(FakeRclip([RClip.SearchResult(path, 1) for path in paths]), str(tmp_path))
+  loaded: list[str] = []
+
+  def track_prepare(filepath: str, size: tuple[int, int]):
+    if size == (1920, 1920):
+      loaded.append(filepath)
+    return prepare_image(filepath, size)
+
+  monkeypatch.setattr("rclip.tui.views.prepare_image", track_prepare)
+
+  async def run() -> None:
+    async with app.run_test(size=(width, 40)) as pilot:
+      await app.workers.wait_for_complete()
+      await pilot.press("down")
+      app.select_card(app.query_one(ResultsGrid).cards[2])
+      app.action_open_detail()
+      await app.workers.wait_for_complete()
+      screen = app.query_one(DetailView)
+      assert sorted(loaded) == paths[1:4]
+      prepared = dict(screen._details)
+      for move, index in [(app.action_move_left, 1), (app.action_move_right, 2)]:
+        move()
+        # Check before yielding: navigation must display the cached image synchronously.
+        assert screen.filepath == paths[index]
+        assert screen._image.image is prepared[paths[index]]
+        assert screen._image.display
+        assert not screen.query_one("#detail-status", Static).display
+      async with asyncio.timeout(1):
+        while set(screen._details) != set(paths[1:4]):
+          await asyncio.sleep(0.001)
+      assert set(screen._details) == set(paths[1:4])
+      assert loaded.count(paths[1]) == loaded.count(paths[2]) == 1
+      app.action_move_left()
+      async with asyncio.timeout(1):
+        while set(screen._details) != set(paths[:3]):
+          await asyncio.sleep(0.001)
+      app.action_move_left()
+      assert set(screen._details) == set(paths[:2])
+
+  asyncio.run(run())
+
+
+def test_detail_reuses_inflight_preload_and_ignores_evicted_completion(
+  tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+  paths = [str(make_image(tmp_path / f"image-{index}.jpg")) for index in range(4)]
+  app = RclipApp(FakeRclip([RClip.SearchResult(path, 1) for path in paths]), str(tmp_path))
+  started = Event()
+  release = Event()
+  loaded: list[str] = []
+
+  def slow_prepare(filepath: str, size: tuple[int, int]):
+    if size == (1920, 1920):
+      loaded.append(filepath)
+      if filepath in paths[:2]:
+        started.set()
+        assert release.wait(5)
+    return prepare_image(filepath, size)
+
+  monkeypatch.setattr("rclip.tui.views.prepare_image", slow_prepare)
+
+  async def run() -> None:
+    async with app.run_test(size=(100, 40)) as pilot:
+      try:
+        await app.workers.wait_for_complete()
+        await pilot.press("down", "o")
+        assert await asyncio.to_thread(started.wait, 1)
+        screen = app.query_one(DetailView)
+        pending = screen._detail_workers[paths[1]]
+        app.action_move_right()
+        assert screen._detail_workers[paths[1]] is pending
+        app.action_move_right()
+      finally:
+        release.set()
+      async with asyncio.timeout(1):
+        while set(screen._details) != set(paths[1:]):
+          await asyncio.sleep(0.001)
+      assert screen.filepath == paths[2]
+      assert screen._image.image is screen._details[paths[2]]
+      assert set(screen._details) == set(paths[1:])
+      assert loaded.count(paths[1]) == 1
+
+  asyncio.run(run())
+
+
 def test_detail_loading_and_error_keep_layout_stable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
   path = make_image(tmp_path / "image.jpg")
   missing = tmp_path / "missing.jpg"


### PR DESCRIPTION
## How does this PR impact the user?

- Moving next or previous in detail view displays an already preloaded image immediately, without waiting for it to load from disk.

## Description

- [x] preload the previous and next detail images independently of the filmstrip width, retaining only the current image and its immediate neighbors
- [x] reuse pending loads, cancel obsolete workers, and ignore stale completions
- [x] add regression coverage for immediate navigation, narrow terminals, cache eviction, and navigation during preloading

## Limitations

- Navigation can still wait if the adjacent image has not finished preloading; terminal rendering and transfer still occur on display.
- End-to-end tests could not download the model because sandbox network access is restricted.

## Validation

- Unit tests, Ruff, type checking, and `git diff --check` pass.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
