### PR TITLE
ci: preserve Homebrew dependency extras when generating the formula

### DIFF
--- a/release-utils/homebrew/generate_formula.py
+++ b/release-utils/homebrew/generate_formula.py
@@ -8,6 +8,7 @@ from typing import AbstractSet, NotRequired, Optional, TypedDict, cast
 import jinja2
 from packaging.markers import default_environment
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 import requests
 import sys
 
@@ -92,6 +93,8 @@ TEMPLATE = env.from_string("""class Rclip < Formula
       end
     end
 {% endif %}
+
+    system "python{{ target_python_version }}", "-m", "pip", "--python=#{libexec}/bin/python", "check"
 
     system libexec/"bin/python", "-m", "rclip._compliance", "collect",
            "--root", libexec, "--output", share/"doc/rclip",
@@ -205,47 +208,45 @@ def render_resource_block(resource: PackageResource, indent: str = "  ") -> str:
 def make_graph(package_name: str, skip_pypi_packages: set[str]):
   marker_env = get_marker_environment({"sys_platform": "linux", "platform_system": "Linux"})
   result = OrderedDict()
-  queue = [package_name]
+  queue = [Requirement(package_name)]
   visited = set()
   while queue:
     pkg = queue.pop(0)
-    key = pkg.lower().replace("-", "_")
+    key = (canonicalize_name(pkg.name), frozenset(pkg.extras))
     if key in visited:
       continue
     visited.add(key)
-    if key in EXTRA_MACOS_RESOURCE_KEYS:
+    if pkg.name.lower().replace("-", "_") in EXTRA_MACOS_RESOURCE_KEYS:
       continue
-    try:
-      dist = importlib.metadata.distribution(pkg)
-    except importlib.metadata.PackageNotFoundError:
-      continue
+    dist = importlib.metadata.distribution(pkg.name)
     actual_name = dist.metadata["Name"]
     version = dist.metadata["Version"]
     if actual_name.lower() in MAKE_GRAPH_IGNORED:
       continue
-    if actual_name.lower() in skip_pypi_packages:
-      result[actual_name.lower().replace("_", "-")] = {
-        "name": actual_name,
-        "version": version,
-      }
-    else:
-      resp = requests.get(f"https://pypi.org/pypi/{actual_name}/{version}/json", timeout=REQUEST_TIMEOUT)
-      resp.raise_for_status()
-      data = resp.json()
-      sdist = next((url_entry for url_entry in data["urls"] if url_entry["packagetype"] == "sdist"), None)
-      url_info = sdist or next(iter(data["urls"]), None)
-      result[actual_name.lower().replace("_", "-")] = {
-        "name": actual_name,
-        "version": version,
-        "url": url_info["url"] if url_info else "",
-        "checksum": url_info["digests"]["sha256"] if url_info else "",
-        "checksum_type": "sha256",
-        "homepage": data["info"]["home_page"] or "",
-      }
+    if actual_name.lower().replace("_", "-") not in result:
+      if actual_name.lower() in skip_pypi_packages:
+        result[actual_name.lower().replace("_", "-")] = {
+          "name": actual_name,
+          "version": version,
+        }
+      else:
+        resp = requests.get(f"https://pypi.org/pypi/{actual_name}/{version}/json", timeout=REQUEST_TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        sdist = next((url_entry for url_entry in data["urls"] if url_entry["packagetype"] == "sdist"), None)
+        url_info = sdist or next(iter(data["urls"]), None)
+        result[actual_name.lower().replace("_", "-")] = {
+          "name": actual_name,
+          "version": version,
+          "url": url_info["url"] if url_info else "",
+          "checksum": url_info["digests"]["sha256"] if url_info else "",
+          "checksum_type": "sha256",
+          "homepage": data["info"]["home_page"] or "",
+        }
     for req_str in dist.requires or []:
       req = Requirement(req_str)
-      if "extra" not in str(req.marker or "") and (req.marker is None or req.marker.evaluate(marker_env)):
-        queue.append(req.name)
+      if req.marker is None or any(req.marker.evaluate({**marker_env, "extra": extra}) for extra in {"", *pkg.extras}):
+        queue.append(req)
   return result
 
 
@@ -283,33 +284,31 @@ def get_macos_arm_wheel_resource(package_name: str, version: str, tag: str) -> P
 def get_macos_only_resources() -> OrderedDict[str, PackageResource]:
   marker_env = get_marker_environment({"sys_platform": "darwin", "platform_system": "Darwin"})
   resources: dict[str, PackageResource] = {}
-  queue = list(EXTRA_MACOS_RESOURCES)
+  queue = [Requirement(name) for name in EXTRA_MACOS_RESOURCES]
   visited = set()
   while queue:
-    package_name = queue.pop(0)
-    key = package_name.lower().replace("-", "_")
+    pkg = queue.pop(0)
+    key = (canonicalize_name(pkg.name), frozenset(pkg.extras))
     if key in visited:
       continue
     visited.add(key)
 
-    dist = importlib.metadata.distribution(package_name)
+    dist = importlib.metadata.distribution(pkg.name)
     actual_name = dist.metadata["Name"]
     version = dist.metadata["Version"]
     normalized_name = actual_name.lower().replace("_", "-")
-    if normalized_name == MACOS_WHEEL_RESOURCE:
-      resources[normalized_name] = get_macos_arm_wheel_resource(actual_name, version, TARGET_PYTHON_TAG)
-    else:
-      resources[normalized_name] = get_pypi_resource(actual_name, version)
+    if normalized_name not in resources:
+      if normalized_name == MACOS_WHEEL_RESOURCE:
+        resources[normalized_name] = get_macos_arm_wheel_resource(actual_name, version, TARGET_PYTHON_TAG)
+      else:
+        resources[normalized_name] = get_pypi_resource(actual_name, version)
 
     for req_str in dist.requires or []:
       req = Requirement(req_str)
       if req.name.lower() in BREW_DEPS:
         continue
-      if "extra" in str(req.marker or ""):
-        continue
-      if req.marker is not None and not req.marker.evaluate(marker_env):
-        continue
-      queue.append(req.name)
+      if req.marker is None or any(req.marker.evaluate({**marker_env, "extra": extra}) for extra in {"", *pkg.extras}):
+        queue.append(req)
 
   return OrderedDict(sorted(resources.items()))
 

--- a/tests/unit/test_generate_formula.py
+++ b/tests/unit/test_generate_formula.py
@@ -59,3 +59,77 @@ def test_formula_uses_explicit_compliance_inputs() -> None:
 
   assert '"--policy", buildpath/"compliance/policy.toml"' in formula
   assert '"--common-notices", buildpath/"compliance/notices"' in formula
+
+
+@pytest.mark.parametrize("macos", [False, True])
+def test_dependency_graph_preserves_extras(monkeypatch: pytest.MonkeyPatch, macos: bool):
+  from types import SimpleNamespace
+
+  dependencies = {
+    "root": ["markdown-it-py", "textual"],
+    "textual": ["markdown-it-py[linkify]"],
+    "markdown-it-py": [
+      "mdurl",
+      'linkify-it-py[unicode]; extra == "linkify"',
+      'unrequested; extra == "plugins"',
+      'wrong-platform; extra == "linkify" and sys_platform == "win32"',
+      'base-only; extra != "linkify"',
+    ],
+    "mdurl": [],
+    "base-only": [],
+    "linkify-it-py": ['unicode-helper; extra == "unicode"', "markdown-it-py[linkify]"],
+    "unicode-helper": [],
+  }
+  fetched = []
+
+  def distribution(name):
+    return SimpleNamespace(metadata={"Name": name, "Version": "1.0"}, requires=dependencies[name])
+
+  def get(url, timeout):
+    name = url.split("/")[-3]
+    fetched.append(name)
+    return SimpleNamespace(
+      raise_for_status=lambda: None,
+      json=lambda: {
+        "urls": [{"packagetype": "sdist", "url": f"https://example.test/{name}.tar.gz", "digests": {"sha256": "hash"}}],
+        "info": {"home_page": ""},
+      },
+    )
+
+  monkeypatch.setattr(generate_formula.importlib.metadata, "distribution", distribution)
+  monkeypatch.setattr(generate_formula.requests, "get", get)
+  if macos:
+    monkeypatch.setattr(generate_formula, "EXTRA_MACOS_RESOURCES", ["root"])
+    graph = generate_formula.get_macos_only_resources()
+  else:
+    graph = generate_formula.make_graph("root", set())
+
+  assert set(graph) == set(dependencies)
+  assert sorted(fetched) == sorted(dependencies)
+
+
+def test_dependency_graph_fails_for_missing_distribution(monkeypatch: pytest.MonkeyPatch):
+  def distribution(name):
+    raise generate_formula.importlib.metadata.PackageNotFoundError(name)
+
+  monkeypatch.setattr(generate_formula.importlib.metadata, "distribution", distribution)
+
+  with pytest.raises(generate_formula.importlib.metadata.PackageNotFoundError):
+    generate_formula.make_graph("missing", set())
+
+
+def test_formula_checks_dependencies_after_wheel_installation():
+  formula = generate_formula.TEMPLATE.render(
+    package={"url": "https://example.test/rclip.tar.gz", "checksum": "sha256"},
+    resources="",
+    target_python_version=generate_formula.TARGET_PYTHON_VERSION,
+    wheel_resources="",
+    wheel_names="rawpy",
+    wheel_packages=[{"name": "rawpy"}],
+    include_macos_wheel_resource=True,
+    macos_wheel_resource="coremltools",
+  )
+
+  check = 'system "python3.13", "-m", "pip", "--python=#{libexec}/bin/python", "check"'
+  assert formula.rindex('"install", "--no-deps", valid_wheel') < formula.index(check)
+  assert formula.index(check) < formula.index('"rclip._compliance", "collect"')


### PR DESCRIPTION
## How does this PR impact the user?

- Homebrew resources include requested dependency extras, including Textual's `markdown-it-py[linkify]` dependency on `linkify-it-py`.

## Description

- [x] preserve extras through both dependency walks, revisit new extras, and fetch each resource once
- [x] fail generation for missing distributions and run `pip check` after all formula installations
- [x] add regression coverage for late and nested extras, cycles, marker filtering, and validation ordering

## Limitations

- A full Homebrew rebuild was not run. The existing Homebrew installation fails `pip check` because NumPy 2.5.2 does not satisfy rclip's `numpy~=2.1.3`; that separate dependency policy is unchanged.
- Validation: six formula tests, Ruff, ty, and generated Ruby syntax pass. The generated package set installed with `--no-deps`, plus this checkout, passes `pip check` and Markdown linkification in a fresh Python 3.13 environment. This uses checkout metadata; published rclip 3.3.0 still requires `pi-heif`, which this checkout has removed.

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
